### PR TITLE
fix: update console url for webauth

### DIFF
--- a/phase_cli/cmd/auth.py
+++ b/phase_cli/cmd/auth.py
@@ -125,10 +125,10 @@ def phase_auth(mode="webauth"):
             encoded_data = base64.b64encode(raw_data.encode()).decode()
 
             # Print the link in the console
-            print(f"Please authenticate via the Phase Console: {PHASE_API_HOST}/webauth#{encoded_data}")
+            print(f"Please authenticate via the Phase Console: {PHASE_API_HOST}/webauth/{encoded_data}")
 
             # Open the URL silently
-            open_browser(f"{PHASE_API_HOST}/webauth#{encoded_data}")
+            open_browser(f"{PHASE_API_HOST}/webauth/{encoded_data}")
 
             # Wait for the POST request from the web UI.
             while not server.received_data:


### PR DESCRIPTION
Updates the webauth url to use route params instead of url fragments. 

Related to:https://github.com/phasehq/console/pull/97/commits/191166d5efccd8baba97c1e07c275e876e1c93d1