### PR TITLE
Generate secrets

### DIFF
--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -2,15 +2,18 @@ import sys
 import getpass
 from phase_cli.utils.phase_io import Phase
 from phase_cli.cmd.secrets.list import phase_list_secrets
+from phase_cli.utils.crypto import generate_random_secret
 
-def phase_secrets_create(key=None, env_name=None, phase_app=None):
+def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=None, random_length=None):
     """
-    Creates a new secret, encrypts it, and saves it in PHASE_SECRETS_DIR.
+    Creates a new secret, encrypts it, and sync it with the Phase.
 
     Args:
         key (str, optional): The key of the new secret. Defaults to None.
         env_name (str, optional): The name of the environment where the secret will be created. Defaults to None.
         phase_app (str, optional): The name of the Phase application. Defaults to None.
+        random_type (str, optional): The type of random secret to generate (e.g., 'hex', 'alphanumeric'). Defaults to None.
+        random_length (int, optional): The length of the random secret. Defaults to 32.
     """
 
     # Initialize the Phase class
@@ -21,11 +24,23 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None):
         key = input("🗝️  Please enter the key: ")
     key = key.upper()
 
-    # Check if input is being piped
-    if sys.stdin.isatty():
-        value = getpass.getpass("✨ Please enter the value (hidden): ")
+    # Generate a random value or get value from user
+    if random_type:
+        # Check if length is specified for key128 or key256
+        if random_type in ['key128', 'key256'] and random_length != 32:
+            print("⚠️  Warning: The length argument is ignored for 'key128' and 'key256'. Using default lengths.")
+
+        try:
+            value = generate_random_secret(random_type, random_length)
+        except ValueError as e:
+            print(e)
+            return
     else:
-        value = sys.stdin.read().strip()
+        # Check if input is being piped
+        if sys.stdin.isatty():
+            value = getpass.getpass("✨ Please enter the value (hidden): ")
+        else:
+            value = sys.stdin.read().strip()
 
     try:
         # Encrypt and send secret to the backend using the `create` method

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -24,6 +24,18 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         key = input("🗝️  Please enter the key: ")
     key = key.upper()
 
+    # Check if the secret already exists
+    try:
+        secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app)
+        secret_data = next((secret for secret in secrets_data if secret["key"] == key), None)
+        if secret_data:
+            optional_flags = f"--env {env_name} --app {phase_app}" if env_name or phase_app else ""
+            print(f"🗝️  Secret with key '{key}' already exists. Use 'phase secrets update {key} {optional_flags}' to update it.")
+            return
+    except ValueError as e:
+        print(e)
+        return
+
     # Generate a random value or get value from user
     if random_type:
         # Check if length is specified for key128 or key256

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -22,29 +22,29 @@ def phase_secrets_env_export(env_name=None, phase_app=None, keys=None):
 
     try:
         secrets = phase.get(env_name=env_name, keys=keys, app_name=phase_app)
+
+        # Create a dictionary from the fetched secrets for easy look-up
+        secrets_dict = {secret["key"]: secret["value"] for secret in secrets}
+
+        # Iterate through the secrets and resolve references
+        for key, value in secrets_dict.items():
+
+            # Handle cross environment references
+            cross_env_matches = re.findall(cross_env_pattern, value)
+            for ref_env, ref_key in cross_env_matches:
+                try:
+                    ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
+                    value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
+                except ValueError as e:
+                    print(f"# Warning: The environment '{ref_env}' for key '{key}' either does not exist or you do not have access to it.")
+
+            # Handle local references
+            local_ref_matches = re.findall(local_ref_pattern, value)
+            for ref_key in local_ref_matches:
+                value = value.replace(f"${{{ref_key}}}", secrets_dict.get(ref_key, ""))
+            
+            # Print the key-value pair
+            print(f'{key}="{value}"')
+
     except ValueError as e:
-        print(f"Failed to fetch secrets: The environment '{env_name}' either does not exist or you do not have access to it.")
-        sys.exit(1)
-
-    # Create a dictionary from the fetched secrets for easy look-up
-    secrets_dict = {secret["key"]: secret["value"] for secret in secrets}
-
-    # Iterate through the secrets and resolve references
-    for key, value in secrets_dict.items():
-
-        # Handle cross environment references
-        cross_env_matches = re.findall(cross_env_pattern, value)
-        for ref_env, ref_key in cross_env_matches:
-            try:
-                ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
-                value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
-            except ValueError as e:
-                print(f"# Warning: The environment '{ref_env}' for key '{key}' either does not exist or you do not have access to it.")
-
-        # Handle local references
-        local_ref_matches = re.findall(local_ref_pattern, value)
-        for ref_key in local_ref_matches:
-            value = value.replace(f"${{{ref_key}}}", secrets_dict.get(ref_key, ""))
-        
-        # Print the key-value pair
-        print(f'{key}="{value}"')
+        print(e)

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -27,7 +27,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None):
 
         # If no matching secret found, raise an error
         if not secret_data:
-            print(f"No secret found for key: {key}")
+            print(f"🔍 No secret found for key: {key}")
             return
         
     except ValueError as e:

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -2,15 +2,18 @@ import sys
 import getpass
 from phase_cli.utils.phase_io import Phase
 from phase_cli.cmd.secrets.list import phase_list_secrets
+from phase_cli.utils.crypto import generate_random_secret
 
-def phase_secrets_update(key, env_name=None, phase_app=None):
+def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, random_length=None):
     """
-    Updates a secret with a new value.
+    Updates a secret with a new value or a randomly generated value.
 
     Args:
         key (str): The key of the secret to update.
         env_name (str, optional): The name of the environment in which the secret is located. Defaults to None.
         phase_app (str, optional): The name of the Phase application. Defaults to None.
+        random_type (str, optional): The type of random secret to generate (e.g., 'hex', 'alphanumeric'). Defaults to None.
+        random_length (int, optional): The length of the random secret. Defaults to 32.
     """
     # Initialize the Phase class
     phase = Phase()
@@ -18,39 +21,42 @@ def phase_secrets_update(key, env_name=None, phase_app=None):
     # Convert the key to uppercase
     key = key.upper()
 
+    # Check if the secret exists
     try:
-        # Pass the key within a list to the get method
         secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app)
-
-        # Find the specific secret for the given key
         secret_data = next((secret for secret in secrets_data if secret["key"] == key), None)
-
-        # If no matching secret found, raise an error
         if not secret_data:
             print(f"🔍 No secret found for key: {key}")
             return
-        
     except ValueError as e:
         print(e)
+        return
 
-    # Check if input is being piped
-    if sys.stdin.isatty():
-        new_value = getpass.getpass(f"Please enter the new value for {key} (hidden): ")
+    # Generate a random value or get value from user
+    if random_type:
+        # Check if length is specified for key128 or key256
+        if random_type in ['key128', 'key256'] and random_length != 32:
+            print("⚠️  Warning: The length argument is ignored for 'key128' and 'key256'. Using default lengths.")
+
+        try:
+            new_value = generate_random_secret(random_type, random_length)
+        except ValueError as e:
+            print(e)
+            return
     else:
-        new_value = sys.stdin.read().strip()
+        # Check if input is being piped
+        if sys.stdin.isatty():
+            new_value = getpass.getpass(f"Please enter the new value for {key} (hidden): ")
+        else:
+            new_value = sys.stdin.read().strip()
 
+    # Update the secret
     try:
-        # Call the update method of the Phase class
         response = phase.update(env_name=env_name, key=key, value=new_value, app_name=phase_app)
-        
-        # Check the response status code (assuming the update method returns a response with a status code)
         if response == "Success":
-            print("Successfully updated the secret. ")
+            print("Successfully updated the secret.")
         else:
             print(f"Error: Failed to update secret. HTTP Status Code: {response.status_code}")
-
-        # List remaining secrets (censored by default)
         phase_list_secrets(show=False, env_name=env_name)
-    
     except ValueError:
         print(f"⚠️  Error occurred while updating the secret.")

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -104,7 +104,6 @@ def main ():
             "🔏 : Indicates a personal secret, visible only to the user who set it."
         )
 
-
         # Secrets get command
         secrets_get_parser = secrets_subparsers.add_parser('get', help='🔍 Get a specific secret by key')
         secrets_get_parser.add_argument('key', type=str, help='The key associated with the secret to fetch')
@@ -147,7 +146,7 @@ def main ():
         # Secrets update command
         secrets_update_parser = secrets_subparsers.add_parser(
             'update', 
-            description='📝 Update an existing secret. Optionally, you can provide the new secret value via stdin.\n\nExample:\n  cat ~/.ssh/id_ed25519 | phase secrets update SSH_PRIVATE_KEY',
+            description='📝 Update an existing secret. Optionally, you can provide the new secret value via stdin or generate a random value of a specified type and length.\n\nExample:\n  cat ~/.ssh/id_ed25519 | phase secrets update SSH_PRIVATE_KEY\n  phase secrets update MY_SECRET_KEY --random hex --length 32',
             help='📝 Update an existing secret'
         )
         secrets_update_parser.add_argument(
@@ -157,6 +156,19 @@ def main ():
         )
         secrets_update_parser.add_argument('--env', type=str, help=env_help)
         secrets_update_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+
+        # Adding the --random argument
+        random_types = ['hex', 'alphanumeric', 'base64', 'base64url', 'key128', 'key256']
+        secrets_update_parser.add_argument('--random', 
+                                        type=str, 
+                                        choices=random_types, 
+                                        help='🎲 Specify the type of random value to generate. Available types: ' + ', '.join(random_types) + '. Example usage: --random hex')
+
+        # Adding the --length argument
+        secrets_update_parser.add_argument('--length', 
+                                        type=int, 
+                                        default=32, 
+                                        help='🔢 Specify the length of the random value. Applicable for types other than key128 and key256. Default is 32. Example usage: --length 16')
 
         # Secrets delete command
         secrets_delete_parser = secrets_subparsers.add_parser('delete', help='🗑️` Delete a secret')
@@ -237,7 +249,7 @@ def main ():
             elif args.secrets_command == 'export':
                 phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app)
             elif args.secrets_command == 'update':
-                phase_secrets_update(args.key, env_name=args.env, phase_app=args.app)
+                phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, random_type=args.random, random_length=args.length)
             else:
                 print("Unknown secrets sub-command: " + args.secrets_command)
                 parser.print_help()

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -119,7 +119,7 @@ def main ():
         # Secrets create command
         secrets_create_parser = secrets_subparsers.add_parser(
             'create', 
-            description='💳 Create a new secret. Optionally, you can provide the secret value via stdin.\n\nExample:\n  cat ~/.ssh/id_rsa | phase secrets create SSH_PRIVATE_KEY',
+            description='💳 Create a new secret. Optionally, you can provide the secret value via stdin, or generate a random value of a specified type and length.\n\nExamples:\n  cat ~/.ssh/id_rsa | phase secrets create SSH_PRIVATE_KEY\n  phase secrets create RAND --random hex --length 32',
             help='💳 Create a new secret'
         )
         secrets_create_parser.add_argument(
@@ -130,6 +130,19 @@ def main ():
         )
         secrets_create_parser.add_argument('--env', type=str, help=env_help)
         secrets_create_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+
+        # Adding the --random argument
+        random_types = ['hex', 'alphanumeric', 'base64', 'base64url', 'key128', 'key256']
+        secrets_create_parser.add_argument('--random', 
+                                        type=str, 
+                                        choices=random_types, 
+                                        help='🎲 Specify the type of random value to generate. Available types: ' + ', '.join(random_types) + '. Example usage: --random hex')
+
+        # Adding the --length argument
+        secrets_create_parser.add_argument('--length', 
+                                        type=int, 
+                                        default=32, 
+                                        help='🔢 Specify the length of the random value. Applicable for types other than key128 and key256. Default is 32. Example usage: --length 16')
 
         # Secrets update command
         secrets_update_parser = secrets_subparsers.add_parser(
@@ -216,7 +229,7 @@ def main ():
             elif args.secrets_command == 'get':
                 phase_secrets_get(args.key, env_name=args.env, phase_app=args.app)  
             elif args.secrets_command == 'create':
-                phase_secrets_create(args.key, env_name=args.env, phase_app=args.app)
+                phase_secrets_create(args.key, env_name=args.env, phase_app=args.app, random_type=args.random, random_length=args.length)
             elif args.secrets_command == 'delete':
                 phase_secrets_delete(args.keys, env_name=args.env, phase_app=args.app)  
             elif args.secrets_command == 'import':

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -96,6 +96,7 @@ def main ():
         secrets_list_parser = secrets_subparsers.add_parser('list', help='📇 List all the secrets')
         secrets_list_parser.add_argument('--show', action='store_true', help='Return secrets uncensored')
         secrets_list_parser.add_argument('--env', type=str, help=env_help)
+        secrets_list_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
         secrets_list_parser.epilog = (
             "🔗 : Indicates that the secret value references another secret within the same environment.\n"
             "⛓️ : Indicates a cross-environment reference, where a secret in the current environment references a secret from another environment.\n"
@@ -107,6 +108,7 @@ def main ():
         secrets_get_parser = secrets_subparsers.add_parser('get', help='🔍 Get a specific secret by key')
         secrets_get_parser.add_argument('key', type=str, help='The key associated with the secret to fetch')
         secrets_get_parser.add_argument('--env', type=str, help=env_help)
+        secrets_get_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
         secrets_get_parser.epilog = (
             "🔗 : Indicates that the secret value references another secret within the same environment.\n"
             "⛓️ : Indicates a cross-environment reference, where a secret in the current environment references a secret from another environment.\n"
@@ -126,6 +128,7 @@ def main ():
             help='The key for the secret to be created. (Will be converted to uppercase.) If the value is not provided as an argument, it will be read from stdin.'
         )
         secrets_create_parser.add_argument('--env', type=str, help=env_help)
+        secrets_create_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
 
         # Secrets update command
         secrets_update_parser = secrets_subparsers.add_parser(
@@ -139,21 +142,25 @@ def main ():
             help='The key associated with the secret to update. If the new value is not provided as an argument, it will be read from stdin.'
         )
         secrets_update_parser.add_argument('--env', type=str, help=env_help)
+        secrets_update_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
 
         # Secrets delete command
         secrets_delete_parser = secrets_subparsers.add_parser('delete', help='🗑️` Delete a secret')
         secrets_delete_parser.add_argument('keys', nargs='*', help='Keys to be deleted')
         secrets_delete_parser.add_argument('--env', type=str, help=env_help)
+        secrets_delete_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
 
         # Secrets import command
         secrets_import_parser = secrets_subparsers.add_parser('import', help='📩 Import secrets from a .env file')
         secrets_import_parser.add_argument('env_file', type=str, help='The .env file to import')
         secrets_import_parser.add_argument('--env', type=str, help=env_help)
+        secrets_import_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
 
         # Secrets export command
         secrets_export_parser = secrets_subparsers.add_parser('export', help='🥡 Export secrets in a dotenv format')
         secrets_export_parser.add_argument('keys', nargs='*', help='List of keys separated by space', default=None)
         secrets_export_parser.add_argument('--env', type=str, help=env_help)
+        secrets_export_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
 
         # Users command
         users_parser = subparsers.add_parser('users', help='👥 Manage users and accounts')
@@ -204,19 +211,19 @@ def main ():
                 sys.exit(1)
         elif args.command == 'secrets':
             if args.secrets_command == 'list':
-                phase_list_secrets(args.show, env_name=args.env)
+                phase_list_secrets(args.show, env_name=args.env, phase_app=args.app)
             elif args.secrets_command == 'get':
-                phase_secrets_get(args.key, env_name=args.env)  
+                phase_secrets_get(args.key, env_name=args.env, phase_app=args.app)  
             elif args.secrets_command == 'create':
-                phase_secrets_create(args.key, env_name=args.env)
+                phase_secrets_create(args.key, env_name=args.env, phase_app=args.app)
             elif args.secrets_command == 'delete':
-                phase_secrets_delete(args.keys, env_name=args.env)  
+                phase_secrets_delete(args.keys, env_name=args.env, phase_app=args.app)  
             elif args.secrets_command == 'import':
-                phase_secrets_env_import(args.env_file, env_name=args.env)
+                phase_secrets_env_import(args.env_file, env_name=args.env, phase_app=args.app)
             elif args.secrets_command == 'export':
-                phase_secrets_env_export(env_name=args.env, keys=args.keys)
+                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app)
             elif args.secrets_command == 'update':
-                phase_secrets_update(args.key, env_name=args.env)
+                phase_secrets_update(args.key, env_name=args.env, phase_app=args.app)
             else:
                 print("Unknown secrets sub-command: " + args.secrets_command)
                 parser.print_help()

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -87,6 +87,7 @@ def main ():
         run_parser = subparsers.add_parser('run', help='🚀 Run and inject secrets to your app')
         run_parser.add_argument('command_to_run', nargs=argparse.REMAINDER, help='Command to be run. Ex. phase run yarn dev')
         run_parser.add_argument('--env', type=str, help=env_help)
+        run_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
 
         # Secrets command
         secrets_parser = subparsers.add_parser('secrets', help='🗝️` Manage your secrets')
@@ -192,7 +193,7 @@ def main ():
             phase_init()
         elif args.command == 'run':
             command = ' '.join(args.command_to_run)
-            phase_run_inject(command, env_name=args.env)
+            phase_run_inject(command, env_name=args.env, phase_app=args.app)
         elif args.command == 'console':
             phase_open_web()
         elif args.command == 'update':

--- a/phase_cli/utils/crypto.py
+++ b/phase_cli/utils/crypto.py
@@ -1,5 +1,7 @@
 import base64
 from typing import Tuple
+import string
+from nacl.secret import SecretBox
 from typing import List
 from nacl.encoding import RawEncoder
 import functools
@@ -224,3 +226,34 @@ class CryptoUtils:
         return functools.reduce(
             CryptoUtils.xor_bytes, [bytes.fromhex(share) for share in shares]
         ).hex()
+
+
+def generate_random_secret(type='hex', length=32):
+    """
+    Generates a random secret based on the specified type and length.
+
+    Args:
+        type (str): Type of secret to generate ('alphanumeric', 'hex', 'base64', 'base64url', 'key128', 'key256').
+        length (int): Length of the secret (1 to 256). For 'key128' and 'key256', length is ignored.
+
+    Returns:
+        str: The generated secret.
+    """
+    if not 1 <= length <= 256:
+        raise ValueError("Length must be between 1 and 256.")
+
+    if type == 'alphanumeric':
+        chars = string.ascii_letters + string.digits
+        return ''.join(chars[byte % len(chars)] for byte in nacl.utils.random(length))
+    elif type == 'hex':
+        return nacl.utils.random(length).hex()
+    elif type == 'base64':
+        return base64.b64encode(nacl.utils.random(length)).decode()
+    elif type == 'base64url':
+        return base64.urlsafe_b64encode(nacl.utils.random(length)).decode()
+    elif type == 'key128':
+        return base64.b64encode(nacl.utils.random(SecretBox.KEY_SIZE // 2)).decode()
+    elif type == 'key256':
+        return base64.b64encode(nacl.utils.random(SecretBox.KEY_SIZE)).decode()
+    else:
+        raise ValueError("Invalid secret type specified.")


### PR DESCRIPTION
This change introduces the ability to create secrets for the following `phase secrets` sub commands:
- create 
- update

The following secrets types are currently supported:
- Alphanumeric
- Hex
- Base64
- Base64 URL safe
- key128 : 16 Byte high entropy base64 encoded symmetric key - suitable for AES-128
- key256 : 32 Byte high entropy base64 encoded symmetric key  - suitable for use with ChaCha20 or AES-256

For alphanumeric, base64, base64urlsafe and hex - the length can also be set by passing `--length` flag and can vary from 1 to 256. 

Examples:
```fish
phase secrets create RAND --random alphanumeric --length 256
KEY 🗝️                        | VALUE ✨                                                             
----------------------------------------------------------------------------------------------------
RAND                          | l9Q**************************************************************  
```

```fish
phase secrets create AES_GCM_KEY --random key256
KEY 🗝️                        | VALUE ✨                                                             
----------------------------------------------------------------------------------------------------
AES_GCM_KEY                   | IUO**************************************                       
```