### PR TITLE
Feat  tags comments

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -r requirements.txt
+      - run: pip install -r dev-requirements.txt
       - run: pip install pytest
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$PWD" >> $GITHUB_ENV

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.10.0
+pkgver=1.11.0
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,10 @@
+keyring==24.2.0
+questionary==2.0.0
+cffi==1.15.1
+requests==2.31.0
+PyNaCl==1.5.0
+pytest==7.3.1
+rich==13.5.2
+pyyaml==6.0
+toml==0.10.2
+python-hcl2==4.3.2

--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -4,60 +4,62 @@ import re
 import subprocess
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.const import cross_env_pattern, local_ref_pattern
+from rich.console import Console
+from rich.spinner import Spinner
 
-def phase_run_inject(command, env_name=None, phase_app=None):
+def phase_run_inject(command, env_name=None, phase_app=None, tags=None):
     """
-    Executes a given shell command with the environment variables set to the secrets 
+    Executes a shell command with environment variables set to the secrets 
     fetched from Phase for the specified environment.
-    
-    The function fetches the decrypted secrets, resolves any references to other secrets, 
-    and then runs the specified command with the secrets injected as environment variables.
-    
+
     Args:
         command (str): The shell command to be executed.
-        env_name (str, optional): The name of the environment from which secrets are fetched. Defaults to None.
+        env_name (str, optional): The environment name from which secrets are fetched. Defaults to None.
         phase_app (str, optional): The name of the Phase application. Defaults to None.
-        
-    Raises:
-        ValueError: If there's an issue with fetching the secrets or if the data format is unexpected.
-        Exception: For any subprocess-related errors.
     """
-    
-    # Initialize the Phase class
     phase = Phase()
-    
-    # Fetch the decrypted secrets using the `get` method
-    try:
-        secrets = phase.get(env_name=env_name, app_name=phase_app)
-    except ValueError as e:
-        print(e)
-        sys.exit(1)
-    
-    # Prepare the new environment variables for the command
-    new_env = os.environ.copy()
-    
-    # Create a dictionary from the fetched secrets for easy look-up
-    secrets_dict = {secret["key"]: secret["value"] for secret in secrets}
-    
-    # Iterate through the secrets and resolve references
-    for key, value in secrets_dict.items():
-        
-        # Handle cross environment references
-        cross_env_matches = re.findall(cross_env_pattern, value)
-        for ref_env, ref_key in cross_env_matches:
-            try:
-                ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
-                value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
-            except ValueError as e:
-                print(f"⚠️  Warning: The environment '{ref_env}' for key '{key}' either does not exist or you do not have access to it. Reference {ref_key} not found. Ignoring...")
-                value = value.replace(f"${{{ref_env}.{ref_key}}}", "")
-        
-        # Handle local references
-        local_ref_matches = re.findall(local_ref_pattern, value)
-        for ref_key in local_ref_matches:
-            value = value.replace(f"${{{ref_key}}}", secrets_dict.get(ref_key, f"Warning: Local reference {ref_key} not found for key {key}. Ignoring..."))
-        
-        new_env[key] = value
+    console = Console()
+    status = console.status(Spinner("dots", text="Fetching secrets..."), spinner="dots")
 
-    # Use shell=True to allow command chaining
-    subprocess.run(command, shell=True, env=new_env)
+    try:
+        # Start the spinner
+        status.start()
+
+        # Fetch secrets from Phase
+        secrets = phase.get(env_name=env_name, app_name=phase_app, tag=tags)
+        new_env = os.environ.copy()
+
+        # Create a dictionary from the fetched secrets for easy look-up
+        secrets_dict = {secret["key"]: secret["value"] for secret in secrets}
+        
+        # Iterate through the secrets and resolve references
+        for key, value in secrets_dict.items():
+            
+            # Resolve cross environment references
+            cross_env_matches = re.findall(cross_env_pattern, value)
+            for ref_env, ref_key in cross_env_matches:
+                try:
+                    ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
+                    value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
+                except ValueError as e:
+                    print(f"⚠️  Warning: The environment '{ref_env}' for key '{key}' either does not exist or you do not have access to it. Reference {ref_key} not found. Ignoring...")
+                    value = value.replace(f"${{{ref_env}.{ref_key}}}", "")
+            
+            # Resolve local references
+            local_ref_matches = re.findall(local_ref_pattern, value)
+            for ref_key in local_ref_matches:
+                value = value.replace(f"${{{ref_key}}}", secrets_dict.get(ref_key, f"⚠️  Warning: Local reference {ref_key} not found for key {key}. Ignoring..."))
+            
+            new_env[key] = value
+
+        # Stop the spinner before running the command
+        status.stop()
+
+        # Run the command with the updated environment
+        subprocess.run(command, shell=True, env=new_env)
+
+    except ValueError as e:
+        console.log(f"Error: {e}")
+        sys.exit(1)
+    finally:
+        status.stop()

--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 from phase_cli.utils.phase_io import Phase
+from phase_cli.utils.misc import tag_matches, normalize_tag
 from phase_cli.utils.const import cross_env_pattern, local_ref_pattern
 from rich.console import Console
 from rich.spinner import Spinner
@@ -10,52 +11,42 @@ from rich.spinner import Spinner
 def phase_run_inject(command, env_name=None, phase_app=None, tags=None):
     """
     Executes a shell command with environment variables set to the secrets 
-    fetched from Phase for the specified environment.
+    fetched from Phase for the specified environment, resolving references as needed.
 
     Args:
         command (str): The shell command to be executed.
         env_name (str, optional): The environment name from which secrets are fetched. Defaults to None.
         phase_app (str, optional): The name of the Phase application. Defaults to None.
+        tags (str, optional): Comma-separated list of tags to filter secrets. Defaults to None.
     """
     phase = Phase()
     console = Console()
     status = console.status(Spinner("dots", text="Fetching secrets..."), spinner="dots")
 
     try:
-        # Start the spinner
         status.start()
 
-        # Fetch secrets from Phase
-        secrets = phase.get(env_name=env_name, app_name=phase_app, tag=tags)
-        new_env = os.environ.copy()
+        # Fetch all secrets without filtering by tags
+        all_secrets = phase.get(env_name=env_name, app_name=phase_app)
+        secrets_dict = {secret["key"]: secret["value"] for secret in all_secrets}
 
-        # Create a dictionary from the fetched secrets for easy look-up
-        secrets_dict = {secret["key"]: secret["value"] for secret in secrets}
-        
-        # Iterate through the secrets and resolve references
+        # Resolve references in all secrets
         for key, value in secrets_dict.items():
-            
-            # Resolve cross environment references
-            cross_env_matches = re.findall(cross_env_pattern, value)
-            for ref_env, ref_key in cross_env_matches:
-                try:
-                    ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
-                    value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
-                except ValueError as e:
-                    print(f"⚠️  Warning: The environment '{ref_env}' for key '{key}' either does not exist or you do not have access to it. Reference {ref_key} not found. Ignoring...")
-                    value = value.replace(f"${{{ref_env}.{ref_key}}}", "")
-            
-            # Resolve local references
-            local_ref_matches = re.findall(local_ref_pattern, value)
-            for ref_key in local_ref_matches:
-                value = value.replace(f"${{{ref_key}}}", secrets_dict.get(ref_key, f"⚠️  Warning: Local reference {ref_key} not found for key {key}. Ignoring..."))
-            
-            new_env[key] = value
+            value = resolve_secret(value, secrets_dict, phase, env_name, phase_app)
+            secrets_dict[key] = value
 
-        # Stop the spinner before running the command
+        # Normalize and filter secrets by tags if tags are provided
+        if tags:
+            user_tags = [normalize_tag(tag) for tag in tags.split(',')]
+            tagged_secrets = [secret for secret in all_secrets if any(tag_matches(secret.get("tags", []), user_tag) for user_tag in user_tags)]
+            secrets_dict = {secret["key"]: secrets_dict[secret["key"]] for secret in tagged_secrets}
+
+
+        new_env = os.environ.copy()
+        new_env.update(secrets_dict)
+
         status.stop()
 
-        # Run the command with the updated environment
         subprocess.run(command, shell=True, env=new_env)
 
     except ValueError as e:
@@ -63,3 +54,36 @@ def phase_run_inject(command, env_name=None, phase_app=None, tags=None):
         sys.exit(1)
     finally:
         status.stop()
+
+def resolve_secret(value, secrets_dict, phase, env_name, phase_app):
+    """
+    Resolve references in a secret value.
+
+    Args:
+        value (str): The secret value to resolve.
+        secrets_dict (dict): Dictionary of already fetched secrets.
+        phase (Phase): Phase instance.
+        env_name (str): Environment name.
+        phase_app (str): Phase application name.
+
+    Returns:
+        str: Resolved secret value.
+    """
+    cross_env_matches = re.findall(cross_env_pattern, value)
+    for ref_env, ref_key in cross_env_matches:
+        try:
+            ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
+            value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
+        except ValueError as e:
+            print(f"⚠️  Warning: Issue with {ref_env} for key '{ref_key}'. Reference not found. Ignoring...")
+            value = value.replace(f"${{{ref_env}.{ref_key}}}", "")
+
+    local_ref_matches = re.findall(local_ref_pattern, value)
+    for ref_key in local_ref_matches:
+        if ref_key in secrets_dict:
+            ref_value = secrets_dict[ref_key]
+            value = value.replace(f"${{{ref_key}}}", ref_value)
+        else:
+            print(f"⚠️  Warning: Local reference '{ref_key}' not found. Ignoring...")
+
+    return value

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -63,7 +63,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         # Check the response status code
         if response.status_code == 200:
             # Call the phase_list_secrets function to list the secrets
-            phase_list_secrets(show=False, env_name=env_name)
+            phase_list_secrets(show=False, phase_app=phase_app, env_name=env_name)
         else:
             # Print an error message if the response status code indicates an error
             print(f"Error: Failed to create secret. HTTP Status Code: {response.status_code}")

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -3,6 +3,7 @@ import getpass
 from phase_cli.utils.phase_io import Phase
 from phase_cli.cmd.secrets.list import phase_list_secrets
 from phase_cli.utils.crypto import generate_random_secret
+from rich.console import Console
 
 def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=None, random_length=None):
     """
@@ -18,6 +19,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
 
     # Initialize the Phase class
     phase = Phase()
+    console = Console()
 
     # If the key is not passed as an argument, prompt user for input
     if key is None:
@@ -33,7 +35,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
             print(f"🗝️  Secret with key '{key}' already exists. Use 'phase secrets update {key} {optional_flags}' to update it.")
             return
     except ValueError as e:
-        print(e)
+        console.log(f"Error: {e}")
         return
 
     # Generate a random value or get value from user
@@ -45,7 +47,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         try:
             value = generate_random_secret(random_type, random_length)
         except ValueError as e:
-            print(e)
+            console.log(f"Error: {e}")
             return
     else:
         # Check if input is being piped
@@ -67,4 +69,4 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
             print(f"Error: Failed to create secret. HTTP Status Code: {response.status_code}")
 
     except ValueError as e:
-        print(e)
+        console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/delete.py
+++ b/phase_cli/cmd/secrets/delete.py
@@ -1,5 +1,6 @@
 from phase_cli.utils.phase_io import Phase
 from phase_cli.cmd.secrets.list import phase_list_secrets
+from rich.console import Console
 
 # Deletes encrypted secrets based on key value pairs
 def phase_secrets_delete(keys_to_delete=[], env_name=None, phase_app=None):
@@ -13,6 +14,7 @@ def phase_secrets_delete(keys_to_delete=[], env_name=None, phase_app=None):
     """
     # Initialize the Phase class
     phase = Phase()
+    console = Console()
 
     # If keys_to_delete is empty, request user input
     if not keys_to_delete:
@@ -35,4 +37,4 @@ def phase_secrets_delete(keys_to_delete=[], env_name=None, phase_app=None):
         phase_list_secrets(show=False, env_name=env_name)
     
     except ValueError as e:
-        print(e)
+        console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -2,6 +2,7 @@ import sys
 import re
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.const import cross_env_pattern, local_ref_pattern
+from rich.console import Console
 
 def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None):
     """

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -1,52 +1,183 @@
 import sys
 import re
+import json
+import csv
+import yaml
 from phase_cli.utils.phase_io import Phase
+import xml.sax.saxutils as saxutils
 from phase_cli.utils.const import cross_env_pattern, local_ref_pattern
 from rich.console import Console
 
-def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None):
+console = Console()
+
+def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None, format='dotenv'):
     """
-    Decrypts and exports secrets to a plain text .env format based on the provided environment and keys. 
-    The function also resolves any references to other secrets, whether they are within the same environment 
-    (local references) or from a different environment (cross-environment references). Local references 
-    are indicated using the pattern `${KEY_NAME}`, while cross-environment references use the pattern 
-    `${ENV_NAME.KEY_NAME}`.
+    Exports secrets from the specified environment with support for multiple export formats. 
+    This function fetches secrets from Phase, resolves any cross-environment or local secret references, and then outputs them in the chosen format.
+
+    Supports several formats for exporting secrets:
+    - dotenv (.env): Key-value pairs in a simple text format.
+    - JSON: JavaScript Object Notation, useful for integration with various tools and languages.
+    - CSV: Comma-Separated Values, a simple text format for tabular data.
+    - YAML: Human-readable data serialization format, often used for configuration files.
+    - XML: Extensible Markup Language, suitable for complex data structures.
+    - TOML: Tom's Obvious, Minimal Language, a readable configuration file format.
+    - HCL: HashiCorp Configuration Language, used in HashiCorp tools like Terraform.
+    - INI: A simple format often used for configuration files.
+    - Java Properties: Key-value pair format commonly used in Java applications.
 
     Args:
-        env_name (str, optional): The name of the environment from which secrets are fetched. Defaults to None.
-        phase_app (str, optional): The name of the Phase application. Defaults to None.
-        keys (list, optional): List of keys for which to fetch the secrets. If None, fetches all secrets. Defaults to None.
+        env_name (str, optional): The name of the environment from which to fetch secrets. If None, 
+                                  the default environment is used. Defaults to None.
+        phase_app (str, optional): The name of the Phase application to use. If None, the default 
+                                   application context is used. Defaults to None.
+        keys (list[str], optional): A list of specific secret keys to fetch. If None, all secrets 
+                                    in the environment are fetched. Defaults to None.
+        tags (str, optional): Comma-separated list of tags to filter secrets. Only secrets containing 
+                              these tags will be fetched. Defaults to None.
+        format (str, optional): The format for exporting the secrets. Supported formats include 
+                                'dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 
+                                and 'java_properties'. Defaults to 'dotenv'.
+
+    Raises:
+        ValueError: If any errors occur during the fetching of secrets or if the specified format 
+                    is not supported.
     """
 
-    # Initialize the Phase class
+    # Initialize
     phase = Phase()
-    console = Console()
 
     try:
-        secrets = phase.get(env_name=env_name, keys=keys, app_name=phase_app, tag=tags)
+        # Fetch all secrets
+        all_secrets = phase.get(env_name=env_name, app_name=phase_app, tag=tags)
+        all_secrets_dict = {secret["key"]: secret["value"] for secret in all_secrets}
 
-        # Create a dictionary from the fetched secrets for easy look-up
-        secrets_dict = {secret["key"]: secret["value"] for secret in secrets}
+        # Resolve references
+        resolved_secrets = resolve_references(all_secrets_dict, phase, env_name, phase_app)
 
-        # Iterate through the secrets and resolve references
-        for key, value in secrets_dict.items():
+        # Filter secrets if specific keys are requested
+        secrets_dict = {key: resolved_secrets[key] for key in (keys or resolved_secrets)}
 
-            # Resolve cross environment references
-            cross_env_matches = re.findall(cross_env_pattern, value)
-            for ref_env, ref_key in cross_env_matches:
-                try:
-                    ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
-                    value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
-                except ValueError as e:
-                    print(f"# Warning: The environment '{ref_env}' for key '{key}' either does not exist or you do not have access to it.")
-
-            # Resolve local references
-            local_ref_matches = re.findall(local_ref_pattern, value)
-            for ref_key in local_ref_matches:
-                value = value.replace(f"${{{ref_key}}}", secrets_dict.get(ref_key, ""))
-            
-            # Print the key-value pair
-            print(f'{key}="{value}"')
+        # Export based on selected format
+        if format == 'json':
+            export_json(secrets_dict)
+        elif format == 'csv':
+            export_csv(secrets_dict)
+        elif format == 'yaml':
+            export_yaml(secrets_dict)
+        elif format == 'xml':
+            export_xml(secrets_dict)
+        elif format == 'toml':
+            export_toml(secrets_dict)
+        elif format == 'hcl':
+            export_hcl(secrets_dict)
+        elif format == 'ini':
+            export_ini(secrets_dict)
+        elif format == 'java_properties':
+            export_java_properties(secrets_dict)
+        else:
+            export_dotenv(secrets_dict)
 
     except ValueError as e:
         console.log(f"Error: {e}")
+
+def resolve_references(secrets_dict, phase, env_name, phase_app):
+    """
+    Resolve references in secret values.
+    """
+    for key, value in secrets_dict.items():
+        # Track found references to avoid duplicate warnings
+        found_references = set()
+
+        # Resolve cross-environment references
+        cross_env_matches = re.findall(cross_env_pattern, value)
+        for ref_env, ref_key in cross_env_matches:
+            full_ref = f"{ref_env}.{ref_key}"
+            found_references.add(full_ref)
+
+            try:
+                ref_secrets = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)
+                if ref_secrets:
+                    ref_secret = ref_secrets[0]
+                    value = value.replace(f"${{{full_ref}}}", ref_secret['value'])
+                else:
+                    print(f"# Warning: Secret '{ref_key}' not found in environment '{ref_env}' for key '{key}'.")
+            except ValueError as e:
+                print(f"# Error: Issue with fetching secret '{ref_key}' from environment '{ref_env}' for key '{key}'. {e}")
+
+        # Resolve local references
+        local_ref_matches = re.findall(local_ref_pattern, value)
+        for ref_key in local_ref_matches:
+            if ref_key not in found_references:
+                if ref_key in secrets_dict:
+                    ref_value = secrets_dict[ref_key]
+                    value = value.replace(f"${{{ref_key}}}", ref_value)
+                else:
+                    print(f"# Warning: Local reference '{ref_key}' not found for key '{key}'.")
+
+        secrets_dict[key] = value
+
+    return secrets_dict
+
+
+def export_json(secrets_dict):
+    """Export secrets as JSON."""
+    print(json.dumps(secrets_dict, indent=4))
+
+
+def export_csv(secrets_dict):
+    """Export secrets as CSV."""
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['Key', 'Value'])
+    for key, value in secrets_dict.items():
+        writer.writerow([key, value])
+
+
+def export_yaml(secrets_dict):
+    """Export secrets as YAML."""
+    print(yaml.dump(secrets_dict))
+
+
+def export_toml(secrets_dict):
+    """Export secrets as TOML."""
+    for key, value in secrets_dict.items():
+        print(f'{key} = "{value}"')
+
+
+def export_xml(secrets_dict):
+    """Export secrets as XML."""
+    xml_output = '<Secrets>\n'
+    for key, value in secrets_dict.items():
+        escaped_value = saxutils.escape(value)
+        xml_output += f'  <secret name="{key}">{escaped_value}</secret>\n' # Handle escaping
+    xml_output += '</Secrets>'
+    print(xml_output)
+
+
+def export_dotenv(secrets_dict):
+    """Export secrets in dotenv format."""
+    for key, value in secrets_dict.items():
+        print(f'{key}="{value}"')
+
+
+def export_hcl(secrets_dict):
+    """Export secrets as HCL."""
+    for key, value in secrets_dict.items():
+        escaped_value = value.replace('"', '\\"')  # Escape double quotes
+        print(f'variable "{key}" {{')
+        print(f'  default = "{escaped_value}"')
+        print('}\n')
+
+
+def export_ini(secrets_dict):
+    """Export secrets as INI."""
+    print("[DEFAULT]")  # Add a default section header
+    for key, value in secrets_dict.items():
+        escaped_value = value.replace('%', '%%')  # Escape percent signs
+        print(f'{key} = {escaped_value}')
+
+
+def export_java_properties(secrets_dict):
+    """Export secrets as Java properties file."""
+    for key, value in secrets_dict.items():
+        print(f'{key}={value}')

--- a/phase_cli/cmd/secrets/get.py
+++ b/phase_cli/cmd/secrets/get.py
@@ -1,20 +1,22 @@
 from phase_cli.utils.phase_io import Phase
-from phase_cli.utils.misc import render_table
+from rich import print as rich_print
+from rich.json import JSON
+from rich.console import Console
+import json
 
 def phase_secrets_get(key, env_name=None, phase_app=None):
     """
-    Fetch and print a single secret based on a given key.
+    Fetch and print a single secret based on a given key as beautified JSON with syntax highlighting.
     
     :param key: The key associated with the secret to fetch.
     :param env_name: The name of the environment, if any. Defaults to None.
     """
 
-    # Initialize the Phase class
     phase = Phase()
+    console = Console()
     
     try:
         key = key.upper()
-        # Here we wrap the key in a list since the get method now expects a list of keys
         secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app)
         
         # Find the specific secret for the given key
@@ -27,8 +29,9 @@ def phase_secrets_get(key, env_name=None, phase_app=None):
         if not isinstance(secret_data, dict):
             raise ValueError("Unexpected format: secret data is not a dictionary")
         
-        # Print the secret data in a table-like format
-        render_table([secret_data], show=True)
+        # Convert secret data to JSON and print with syntax highlighting
+        json_data = json.dumps(secret_data, indent=4)
+        rich_print(JSON(json_data))
 
     except ValueError as e:
-        print(e)
+        console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/get.py
+++ b/phase_cli/cmd/secrets/get.py
@@ -1,6 +1,4 @@
 from phase_cli.utils.phase_io import Phase
-from rich import print as rich_print
-from rich.json import JSON
 from rich.console import Console
 import json
 
@@ -29,9 +27,9 @@ def phase_secrets_get(key, env_name=None, phase_app=None, tags=None):
         if not isinstance(secret_data, dict):
             raise ValueError("Unexpected format: secret data is not a dictionary")
         
-        # Convert secret data to JSON and print with syntax highlighting
+        # Convert secret data to JSON and print
         json_data = json.dumps(secret_data, indent=4)
-        rich_print(JSON(json_data))
+        print(json_data)
 
     except ValueError as e:
         console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/get.py
+++ b/phase_cli/cmd/secrets/get.py
@@ -4,7 +4,7 @@ from rich.json import JSON
 from rich.console import Console
 import json
 
-def phase_secrets_get(key, env_name=None, phase_app=None):
+def phase_secrets_get(key, env_name=None, phase_app=None, tags=None):
     """
     Fetch and print a single secret based on a given key as beautified JSON with syntax highlighting.
     
@@ -17,7 +17,7 @@ def phase_secrets_get(key, env_name=None, phase_app=None):
     
     try:
         key = key.upper()
-        secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app)
+        secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app, tag=tags)
         
         # Find the specific secret for the given key
         secret_data = next((secret for secret in secrets_data if secret["key"] == key), None)

--- a/phase_cli/cmd/secrets/import_env.py
+++ b/phase_cli/cmd/secrets/import_env.py
@@ -1,6 +1,7 @@
 import sys
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.misc import render_table, get_default_user_id, sanitize_value
+from rich.console import Console
 
 def phase_secrets_env_import(env_file, env_name=None, phase_app=None):
     """
@@ -16,6 +17,7 @@ def phase_secrets_env_import(env_file, env_name=None, phase_app=None):
     """
     # Initialize the Phase class
     phase = Phase()
+    console = Console()
     
     # Parse the .env file
     secrets = []
@@ -49,4 +51,4 @@ def phase_secrets_env_import(env_file, env_name=None, phase_app=None):
             print(f"Error: Failed to import secrets. HTTP Status Code: {response.status_code}")
 
     except ValueError as e:
-        print(e)
+        console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/list.py
+++ b/phase_cli/cmd/secrets/list.py
@@ -1,23 +1,26 @@
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.misc import render_table
+from rich.console import Console
 
-def phase_list_secrets(show=False, env_name=None, phase_app=None):
+def phase_list_secrets(show=False, env_name=None, phase_app=None, tags=None):
     """
-    Lists the secrets fetched from Phase for the specified environment.
+    Lists the secrets fetched from Phase for the specified environment, optionally filtered by tags.
 
     Args:
         show (bool, optional): Whether to show the decrypted secrets. Defaults to False.
         env_name (str, optional): The name of the environment from which secrets are fetched. Defaults to None.
         phase_app (str, optional): The name of the Phase application. Defaults to None.
+        tags (str, optional): The tag or comma-separated list of tags to filter the secrets. Defaults to None.
 
     Raises:
         ValueError: If the returned secrets data from Phase is not in the expected list format.
     """
     # Initialize the Phase class
     phase = Phase()
+    console = Console()
 
     try:
-        secrets_data = phase.get(env_name=env_name, app_name=phase_app)
+        secrets_data = phase.get(env_name=env_name, app_name=phase_app, tag=tags)
         
         # Check that secrets_data is a list of dictionaries
         if not isinstance(secrets_data, list):
@@ -27,7 +30,8 @@ def phase_list_secrets(show=False, env_name=None, phase_app=None):
         render_table(secrets_data, show=show)
 
         if not show:
-            print("\n🥽 To uncover the secrets, use: phase secrets list --show")
+            print("🥽 To uncover the secrets, use: phase secrets list --show")
+            print ("🔬 To view a secret, use: phase secrets get <key>\n")
 
     except ValueError as e:
-        print(e)
+        console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -59,6 +59,6 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
             print("Successfully updated the secret.")
         else:
             print(f"Error: Failed to update secret. HTTP Status Code: {response.status_code}")
-        phase_list_secrets(show=False, env_name=env_name)
+        phase_list_secrets(show=False, phase_app=phase_app, env_name=env_name)
     except ValueError:
         print(f"⚠️  Error occurred while updating the secret.")

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -3,6 +3,7 @@ import getpass
 from phase_cli.utils.phase_io import Phase
 from phase_cli.cmd.secrets.list import phase_list_secrets
 from phase_cli.utils.crypto import generate_random_secret
+from rich.console import Console
 
 def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, random_length=None):
     """
@@ -17,6 +18,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
     """
     # Initialize the Phase class
     phase = Phase()
+    console = Console()
     
     # Convert the key to uppercase
     key = key.upper()
@@ -29,7 +31,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
             print(f"🔍 No secret found for key: {key}")
             return
     except ValueError as e:
-        print(e)
+        console.log(f"Error: {e}")
         return
 
     # Generate a random value or get value from user
@@ -41,7 +43,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
         try:
             new_value = generate_random_secret(random_type, random_length)
         except ValueError as e:
-            print(e)
+            console.log(f"Error: {e}")
             return
     else:
         # Check if input is being piped

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -67,6 +67,7 @@ class HelpfulParser(argparse.ArgumentParser):
 
 def main ():
     env_help = "Environment name eg. dev, staging, production"
+    tag_help = '🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".'
     console = Console()
 
     try:
@@ -88,7 +89,7 @@ def main ():
         run_parser.add_argument('command_to_run', nargs=argparse.REMAINDER, help='Command to be run. Ex. phase run yarn dev')
         run_parser.add_argument('--env', type=str, help=env_help)
         run_parser.add_argument('--app', type=str, help='Name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
-        run_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
+        run_parser.add_argument('--tags', type=str, help=tag_help)
 
         # Secrets command
         secrets_parser = subparsers.add_parser('secrets', help='🗝️` Manage your secrets')
@@ -99,7 +100,7 @@ def main ():
         secrets_list_parser.add_argument('--show', action='store_true', help='Return secrets uncensored')
         secrets_list_parser.add_argument('--env', type=str, help=env_help)
         secrets_list_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
-        secrets_list_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
+        secrets_list_parser.add_argument('--tags', type=str, help=tag_help)
         secrets_list_parser.epilog = (
             "🔗 : Indicates that the secret value references another secret within the same environment.\n"
             "⛓️ : Indicates a cross-environment reference, where a secret in the current environment references a secret from another environment.\n"
@@ -114,7 +115,7 @@ def main ():
         secrets_get_parser.add_argument('key', type=str, help='The key associated with the secret to fetch')
         secrets_get_parser.add_argument('--env', type=str, help=env_help)
         secrets_get_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
-        secrets_get_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
+        secrets_get_parser.add_argument('--tags', type=str, help=tag_help)
 
         # Secrets create command
         secrets_create_parser = secrets_subparsers.add_parser(
@@ -188,7 +189,7 @@ def main ():
         secrets_export_parser.add_argument('keys', nargs='*', help='List of keys separated by space', default=None)
         secrets_export_parser.add_argument('--env', type=str, help=env_help)
         secrets_export_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
-        secrets_export_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
+        secrets_export_parser.add_argument('--tags', type=str, help=tag_help)
 
         # Users command
         users_parser = subparsers.add_parser('users', help='👥 Manage users and accounts')

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -19,10 +19,9 @@ from phase_cli.cmd.secrets.import_env import phase_secrets_env_import
 from phase_cli.cmd.secrets.delete import phase_secrets_delete
 from phase_cli.cmd.secrets.create import phase_secrets_create
 from phase_cli.cmd.secrets.update import phase_secrets_update
-
 from phase_cli.utils.const import __version__
 from phase_cli.utils.const import phaseASCii, description
-
+from rich.console import Console
 
 def print_phase_cli_version():
     print(f"Version: {__version__}")
@@ -68,6 +67,7 @@ class HelpfulParser(argparse.ArgumentParser):
 
 def main ():
     env_help = "Environment name eg. dev, staging, production"
+    console = Console()
 
     try:
         parser = HelpfulParser(prog='phase-cli', formatter_class=RawTextHelpFormatter)
@@ -266,7 +266,7 @@ def main ():
             traceback.print_exc()
         else:
             # When PHASE_DEBUG is set to False, print only the error message
-            print(str(e))
+            console.log(f"Error: {e}")
         sys.exit(1)
 
 if __name__ == '__main__':

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -189,6 +189,7 @@ def main ():
         secrets_export_parser.add_argument('keys', nargs='*', help='List of keys separated by space', default=None)
         secrets_export_parser.add_argument('--env', type=str, help=env_help)
         secrets_export_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_export_parser.add_argument('--format', type=str, default='dotenv', choices=['dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 'java_properties'], help='Specifies the export format. Supported formats: dotenv (default), json, csv, yaml, xml, toml, hcl, ini, java_properties.')
         secrets_export_parser.add_argument('--tags', type=str, help=tag_help)
 
         # Users command
@@ -250,7 +251,7 @@ def main ():
             elif args.secrets_command == 'import':
                 phase_secrets_env_import(args.env_file, env_name=args.env, phase_app=args.app)
             elif args.secrets_command == 'export':
-                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, tags=args.tags)
+                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, tags=args.tags, format=args.format)
             elif args.secrets_command == 'update':
                 phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, random_type=args.random, random_length=args.length)
             else:

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -87,7 +87,8 @@ def main ():
         run_parser = subparsers.add_parser('run', help='🚀 Run and inject secrets to your app')
         run_parser.add_argument('command_to_run', nargs=argparse.REMAINDER, help='Command to be run. Ex. phase run yarn dev')
         run_parser.add_argument('--env', type=str, help=env_help)
-        run_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        run_parser.add_argument('--app', type=str, help='Name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        run_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
 
         # Secrets command
         secrets_parser = subparsers.add_parser('secrets', help='🗝️` Manage your secrets')
@@ -98,22 +99,22 @@ def main ():
         secrets_list_parser.add_argument('--show', action='store_true', help='Return secrets uncensored')
         secrets_list_parser.add_argument('--env', type=str, help=env_help)
         secrets_list_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_list_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
         secrets_list_parser.epilog = (
             "🔗 : Indicates that the secret value references another secret within the same environment.\n"
             "⛓️ : Indicates a cross-environment reference, where a secret in the current environment references a secret from another environment.\n"
+            "🏷️ : Indicates a tag is associated with a secret.\n"
+            "💬 : Indicates a comment is associated with a given secret.\n" 
             "🔏 : Indicates a personal secret, visible only to the user who set it."
+
         )
 
         # Secrets get command
-        secrets_get_parser = secrets_subparsers.add_parser('get', help='🔍 Get a specific secret by key')
+        secrets_get_parser = secrets_subparsers.add_parser('get', help='🔍 Fetch details about a secret in JSON')
         secrets_get_parser.add_argument('key', type=str, help='The key associated with the secret to fetch')
         secrets_get_parser.add_argument('--env', type=str, help=env_help)
         secrets_get_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
-        secrets_get_parser.epilog = (
-            "🔗 : Indicates that the secret value references another secret within the same environment.\n"
-            "⛓️ : Indicates a cross-environment reference, where a secret in the current environment references a secret from another environment.\n"
-            "🔏 : Indicates a personal secret, visible only to the user who set it."
-        )
+        secrets_get_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
 
         # Secrets create command
         secrets_create_parser = secrets_subparsers.add_parser(
@@ -187,6 +188,7 @@ def main ():
         secrets_export_parser.add_argument('keys', nargs='*', help='List of keys separated by space', default=None)
         secrets_export_parser.add_argument('--env', type=str, help=env_help)
         secrets_export_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_export_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
 
         # Users command
         users_parser = subparsers.add_parser('users', help='👥 Manage users and accounts')
@@ -218,7 +220,7 @@ def main ():
             phase_init()
         elif args.command == 'run':
             command = ' '.join(args.command_to_run)
-            phase_run_inject(command, env_name=args.env, phase_app=args.app)
+            phase_run_inject(command, env_name=args.env, phase_app=args.app, tags=args.tags)
         elif args.command == 'console':
             phase_open_web()
         elif args.command == 'update':
@@ -237,9 +239,9 @@ def main ():
                 sys.exit(1)
         elif args.command == 'secrets':
             if args.secrets_command == 'list':
-                phase_list_secrets(args.show, env_name=args.env, phase_app=args.app)
+                phase_list_secrets(args.show, env_name=args.env, phase_app=args.app, tags=args.tags)
             elif args.secrets_command == 'get':
-                phase_secrets_get(args.key, env_name=args.env, phase_app=args.app)  
+                phase_secrets_get(args.key, env_name=args.env, phase_app=args.app, tags=args.tags)  
             elif args.secrets_command == 'create':
                 phase_secrets_create(args.key, env_name=args.env, phase_app=args.app, random_type=args.random, random_length=args.length)
             elif args.secrets_command == 'delete':
@@ -247,7 +249,7 @@ def main ():
             elif args.secrets_command == 'import':
                 phase_secrets_env_import(args.env_file, env_name=args.env, phase_app=args.app)
             elif args.secrets_command == 'export':
-                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app)
+                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, tags=args.tags)
             elif args.secrets_command == 'update':
                 phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, random_type=args.random, random_length=args.length)
             else:

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -35,4 +35,5 @@ pss_user_pattern = re.compile(r"^pss_user:v(\d+):([a-fA-F0-9]{64}):([a-fA-F0-9]{
 pss_service_pattern = re.compile(r"^pss_service:v(\d+):([a-fA-F0-9]{64}):([a-fA-F0-9]{64}):([a-fA-F0-9]{64}):([a-fA-F0-9]{64})$")
 
 cross_env_pattern = re.compile(r"\$\{(.+?)\.(.+?)\}")
-local_ref_pattern = re.compile(r"\$\{(.+?)\}")
+local_ref_pattern = re.compile(r"\$\{([^.]+?)\}")
+

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,6 +1,6 @@
 import os
 import re
-__version__ = "1.10.0"
+__version__ = "1.11.0"
 __ph_version__ = "v1"
 
 description = "Securely manage and sync environment variables with Phase."

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -264,6 +264,37 @@ def phase_get_context(user_data, app_name=None, env_name=None):
         raise ValueError("🔍 Application or environment not found.")
 
 
+def normalize_tag(tag):
+    """
+    Normalize a tag by replacing underscores with spaces.
+
+    Args:
+        tag (str): The tag to normalize.
+
+    Returns:
+        str: The normalized tag.
+    """
+    return tag.replace('_', ' ').lower()
+
+
+def tag_matches(secret_tags, user_tag):
+    """
+    Check if the user-provided tag partially matches any of the secret tags.
+
+    Args:
+        secret_tags (list): The list of tags associated with a secret.
+        user_tag (str): The user-provided tag to match.
+
+    Returns:
+        bool: True if there's a partial match, False otherwise.
+    """
+    normalized_user_tag = normalize_tag(user_tag)
+    for tag in secret_tags:
+        normalized_secret_tag = normalize_tag(tag)
+        if normalized_user_tag in normalized_secret_tag:
+            return True
+    return False
+
 def open_browser(url):
     """Open a URL in the default browser without any console output."""
     # Determine the right command based on the OS

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ questionary==2.0.0
 cffi==1.15.1
 requests==2.31.0
 PyNaCl==1.5.0
+rich==13.5.2

--- a/tests/secrets_export.py
+++ b/tests/secrets_export.py
@@ -1,0 +1,170 @@
+import pytest
+import json
+import yaml
+import csv
+import io
+import toml
+from xml.etree import ElementTree as ET
+from configparser import ConfigParser
+import hcl2
+from unittest.mock import Mock, patch
+from phase_cli.cmd.secrets.export import (
+    export_json, export_csv, export_yaml, export_toml, export_xml,
+    export_dotenv, export_hcl, export_ini, export_java_properties, phase_secrets_env_export, resolve_references
+)
+
+
+secrets_dict = {
+    'AWS_SECRET_ACCESS_KEY': 'aCRAMarEbFC3Q5c24pi7AVMIt6TaCfHeFZ4KCf/a',
+    'AWS_ACCESS_KEY_ID': 'AKIAIX4ONRSG6ODEFVJA',
+    'JWT_SECRET': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjMzNjIwMTcxLCJleHAiOjIyMDg5ODUyMDB9.pHnckabbMbwTHAJOkb5Z7G7B4chY6GllJf6K2m96z3A',
+    'STRIPE_SECRET_KEY': 'sk_test_EeHnL644i6zo4Iyq4v1KdV9H', 
+    'DJANGO_SECRET_KEY': 'wwf*2#86t64!fgh6yav$aoeuo@u2o@fy&*gg76q!&%6x_wbduad',
+    'DJANGO_DEBUG': 'True', 
+    'POSTGRES_CONNECTION_STRING': 'postgresql://postgres:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM', 
+    'DB_HOST': 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com', 
+    'DB_USER': 'postgres', 
+    'DB_NAME': 'XP1_LM', 
+    'DB_PASSWORD': '6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e', 
+    'DB_PORT': '5432'
+}
+
+
+secrets_dict_local_env = {
+    'POSTGRES_CONNECTION_STRING': 'postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}', 
+    'DB_HOST': 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com', 
+    'DB_USER': 'postgres', 
+    'DB_NAME': 'XP1_LM', 
+    'DB_PASSWORD': '6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e', 
+    'DB_PORT': '5432'
+}
+
+
+secrets_dict_cross_env = {
+    'POSTGRES_CONNECTION_STRING': 'postgresql://${production.DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}', 
+    'DB_HOST': 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com', 
+    'DB_USER': 'postgres', 
+    'DB_NAME': 'XP1_LM', 
+    'DB_PASSWORD': '6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e', 
+    'DB_PORT': '5432'
+}
+
+
+secrets_dict_cross_env_prod = {
+    'DB_USER': 'postgres_prod', 
+
+}
+
+
+def test_resolve_references_local_env():
+    # Test local env secret referencing
+    resolved_secrets = resolve_references(secrets_dict_local_env, Mock(), None, None)
+    expected_connection_string = 'postgresql://postgres:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM'
+    assert resolved_secrets['POSTGRES_CONNECTION_STRING'] == expected_connection_string
+
+
+@patch('phase_cli.cmd.secrets.export.Phase')
+def test_resolve_references_cross_env(mock_phase):
+    # Mocking phase.get to return the appropriate secret for cross-environment reference
+    mock_phase_instance = mock_phase.return_value
+    mock_phase_instance.get.return_value = [{'key': 'DB_USER', 'value': 'postgres_prod'}]
+
+    resolved_secrets = resolve_references(secrets_dict_cross_env, mock_phase_instance, None, None)
+    expected_connection_string = 'postgresql://postgres_prod:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM'
+    assert resolved_secrets['POSTGRES_CONNECTION_STRING'] == expected_connection_string
+
+
+@patch('phase_cli.cmd.secrets.export.Phase')
+def test_phase_secrets_env_export_specific_keys(mock_phase, capsys):
+    # Mocking phase.get to return all secrets
+    mock_phase_instance = mock_phase.return_value
+    all_secrets = [{'key': k, 'value': v} for k, v in secrets_dict.items()]
+    mock_phase_instance.get.return_value = all_secrets
+
+    # Call phase_secrets_env_export with specific keys
+    selected_keys = ['AWS_SECRET_ACCESS_KEY', 'AWS_ACCESS_KEY_ID']
+    phase_secrets_env_export(keys=selected_keys)
+
+    # Capture the output
+    captured = capsys.readouterr().out
+
+    # Process the output by splitting and removing double quotes
+    exported_secrets = {line.split('=')[0]: line.split('=')[1].strip('"') for line in captured.strip().split('\n')}
+
+    # Check if only the selected keys are present in the output
+    assert all(key in selected_keys for key in exported_secrets.keys())
+    # Check if the values match the original secrets
+    assert all(exported_secrets[key] == secrets_dict[key] for key in selected_keys)
+
+
+def test_export_json(capsys):
+    export_json(secrets_dict)
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == secrets_dict
+
+
+def test_export_csv(capsys):
+    export_csv(secrets_dict)
+    captured = capsys.readouterr()
+    reader = csv.reader(io.StringIO(captured.out))
+    header = next(reader)
+    assert header == ['Key', 'Value']
+    for row in reader:
+        assert row[0] in secrets_dict
+        assert row[1] == secrets_dict[row[0]]
+
+
+def test_export_yaml(capsys):
+    export_yaml(secrets_dict)
+    captured = capsys.readouterr()
+    assert yaml.safe_load(captured.out) == secrets_dict
+
+
+def test_export_xml(capsys):
+    export_xml(secrets_dict)
+    captured = capsys.readouterr()
+    root = ET.fromstring(captured.out)
+    for secret in root:
+        assert secret.text == secrets_dict[secret.attrib['name']]
+
+
+def test_export_dotenv(capsys):
+    export_dotenv(secrets_dict)
+    captured = capsys.readouterr()
+    for line in captured.out.strip().split('\n'):
+        key, value = line.split('=', 1)
+        assert value.strip('"') == secrets_dict[key]
+
+
+def test_export_toml(capsys):
+    export_toml(secrets_dict)
+    captured = capsys.readouterr()
+    assert toml.loads(captured.out) == secrets_dict
+
+
+def test_export_hcl(capsys):
+    export_hcl(secrets_dict)
+    captured = capsys.readouterr()
+    decoded = hcl2.loads(captured.out)
+    expected_structure = {'variable': []}
+    for key, value in secrets_dict.items():
+        expected_structure['variable'].append({key: {'default': value}})
+    assert decoded == expected_structure
+
+
+def test_export_ini(capsys):
+    export_ini(secrets_dict)
+    captured = capsys.readouterr()
+    parser = ConfigParser()
+    parser.read_string(captured.out)
+    for key in secrets_dict:
+        assert parser['DEFAULT'][key] == secrets_dict[key]
+
+
+def test_export_java_properties(capsys):
+    export_java_properties(secrets_dict)
+    captured = capsys.readouterr()
+    properties = dict(line.split('=', 1) for line in captured.out.strip().split('\n'))
+    for key, value in properties.items():
+        assert value == secrets_dict[key]
+

--- a/tests/tags.py
+++ b/tests/tags.py
@@ -1,0 +1,28 @@
+import pytest
+from phase_cli.utils.misc import tag_matches, normalize_tag
+
+
+full_tag_names = {
+    "prod": ["Production", "ProdData", "NonProd_Environment"],
+    "config": ["ConfigData", "Configuration", "config_file"],
+    "test": ["Test_Tag", "testEnvironment", "Testing_Data"],
+    "dev": ["DevEnv", "DevelopmentData", "dev_tools"],
+    "prod_data": ["prod_data"],
+    "DEV_ENV": []  # No matching tags under the current logic
+}
+
+
+def test_normalize_tag():
+    for tag in full_tag_names:
+        normalized_tag = normalize_tag(tag)
+        assert normalized_tag == tag.replace('_', ' ').lower(), f"Normalization failed for tag: {tag}"
+
+
+def test_tag_matches():
+    for tag, secret_tags in full_tag_names.items():
+        normalized_tag = normalize_tag(tag)
+
+        # Test for matching scenarios
+        for secret_tag in secret_tags:
+            normalized_secret_tag = normalize_tag(secret_tag)
+            assert normalized_tag in normalized_secret_tag, f"Tag '{tag}' should match with secret tag '{secret_tag}'"


### PR DESCRIPTION
## Added support for `--tags` based filtering in phase secrets list, get, export and run

Tags 🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".

Additional changes:
- Added support for comments
- Get now returns secrets in json
```fish
λ phase secrets get POSTGRES_CONNECTION_STRING --tags prod
{
    "key": "POSTGRES_CONNECTION_STRING",
    "value": "postgresql://${production.DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}",
    "overridden": false,
    "tags": [
        "PROD"
    ],
    "comment": "AWS RDS HA 848543535353"
}
```
- Refactored table rendering logic for phase secrets list
![image](https://github.com/phasehq/cli/assets/85357445/8c2e4fd2-7dfa-4ca0-8984-2cef158e7b5f)
- use `rich.console` for logging errors