### PR TITLE
Feat  export formats

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -r requirements.txt
+      - run: pip install -r dev-requirements.txt
       - run: pip install pytest
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$PWD" >> $GITHUB_ENV

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,6 @@ requests==2.31.0
 PyNaCl==1.5.0
 pytest==7.3.1
 rich==13.5.2
+pyyaml==6.0
 toml==0.10.2
 python-hcl2==4.3.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,9 @@
+keyring==24.2.0
+questionary==2.0.0
+cffi==1.15.1
+requests==2.31.0
+PyNaCl==1.5.0
+pytest==7.3.1
+rich==13.5.2
+toml==0.10.2
+python-hcl2==4.3.2

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -1,52 +1,167 @@
 import sys
 import re
+import json
+import csv
+import yaml
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.const import cross_env_pattern, local_ref_pattern
 from rich.console import Console
 
-def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None):
+console = Console()
+
+def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None, format='dotenv'):
     """
-    Decrypts and exports secrets to a plain text .env format based on the provided environment and keys. 
-    The function also resolves any references to other secrets, whether they are within the same environment 
-    (local references) or from a different environment (cross-environment references). Local references 
-    are indicated using the pattern `${KEY_NAME}`, while cross-environment references use the pattern 
-    `${ENV_NAME.KEY_NAME}`.
+    Exports secrets from the specified environment with support for multiple export formats. 
+    This function fetches secrets from Phase, resolves any cross-environment or local secret references, and then outputs them in the chosen format.
+
+    Supports several formats for exporting secrets:
+    - dotenv (.env): Key-value pairs in a simple text format.
+    - JSON: JavaScript Object Notation, useful for integration with various tools and languages.
+    - CSV: Comma-Separated Values, a simple text format for tabular data.
+    - YAML: Human-readable data serialization format, often used for configuration files.
+    - XML: Extensible Markup Language, suitable for complex data structures.
+    - TOML: Tom's Obvious, Minimal Language, a readable configuration file format.
+    - HCL: HashiCorp Configuration Language, used in HashiCorp tools like Terraform.
+    - INI: A simple format often used for configuration files.
+    - Java Properties: Key-value pair format commonly used in Java applications.
 
     Args:
-        env_name (str, optional): The name of the environment from which secrets are fetched. Defaults to None.
-        phase_app (str, optional): The name of the Phase application. Defaults to None.
-        keys (list, optional): List of keys for which to fetch the secrets. If None, fetches all secrets. Defaults to None.
+        env_name (str, optional): The name of the environment from which to fetch secrets. If None, 
+                                  the default environment is used. Defaults to None.
+        phase_app (str, optional): The name of the Phase application to use. If None, the default 
+                                   application context is used. Defaults to None.
+        keys (list[str], optional): A list of specific secret keys to fetch. If None, all secrets 
+                                    in the environment are fetched. Defaults to None.
+        tags (str, optional): Comma-separated list of tags to filter secrets. Only secrets containing 
+                              these tags will be fetched. Defaults to None.
+        format (str, optional): The format for exporting the secrets. Supported formats include 
+                                'dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 
+                                and 'java_properties'. Defaults to 'dotenv'.
+
+    Raises:
+        ValueError: If any errors occur during the fetching of secrets or if the specified format 
+                    is not supported.
     """
 
-    # Initialize the Phase class
+    # Initialize
     phase = Phase()
-    console = Console()
 
     try:
         secrets = phase.get(env_name=env_name, keys=keys, app_name=phase_app, tag=tags)
-
-        # Create a dictionary from the fetched secrets for easy look-up
         secrets_dict = {secret["key"]: secret["value"] for secret in secrets}
 
-        # Iterate through the secrets and resolve references
-        for key, value in secrets_dict.items():
+        # Resolve references
+        secrets_dict = resolve_references(secrets_dict, phase, env_name, phase_app)
 
-            # Resolve cross environment references
-            cross_env_matches = re.findall(cross_env_pattern, value)
-            for ref_env, ref_key in cross_env_matches:
-                try:
-                    ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
-                    value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
-                except ValueError as e:
-                    print(f"# Warning: The environment '{ref_env}' for key '{key}' either does not exist or you do not have access to it.")
-
-            # Resolve local references
-            local_ref_matches = re.findall(local_ref_pattern, value)
-            for ref_key in local_ref_matches:
-                value = value.replace(f"${{{ref_key}}}", secrets_dict.get(ref_key, ""))
-            
-            # Print the key-value pair
-            print(f'{key}="{value}"')
+        # Export based on selected format
+        if format == 'json':
+            export_json(secrets_dict)
+        elif format == 'csv':
+            export_csv(secrets_dict)
+        elif format == 'yaml':
+            export_yaml(secrets_dict)
+        elif format == 'xml':
+            export_xml(secrets_dict)
+        elif format == 'toml':
+            export_toml(secrets_dict)
+        elif format == 'hcl':
+            export_hcl(secrets_dict)
+        elif format == 'ini':
+            export_ini(secrets_dict)
+        elif format == 'java_properties':
+            export_java_properties(secrets_dict)
+        else:  # Default to dotenv
+            export_dotenv(secrets_dict)
 
     except ValueError as e:
         console.log(f"Error: {e}")
+
+def resolve_references(secrets_dict, phase, env_name, phase_app):
+    """
+    Resolve references in secret values.
+
+    Args:
+        secrets_dict (dict): Dictionary of secrets.
+        phase (Phase): Phase instance.
+        env_name (str): Environment name.
+        phase_app (str): Phase application name.
+
+    Returns:
+        dict: Updated secrets dictionary with resolved references.
+    """
+    for key, value in secrets_dict.items():
+        # Resolve cross environment references
+        cross_env_matches = re.findall(cross_env_pattern, value)
+        for ref_env, ref_key in cross_env_matches:
+            try:
+                ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
+                value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
+            except ValueError:
+                print(f"# Warning: Issue with {ref_env} for key {key}. Reference {ref_key} not found.")
+
+        # Resolve local references
+        local_ref_matches = re.findall(local_ref_pattern, value)
+        for ref_key in local_ref_matches:
+            ref_value = secrets_dict.get(ref_key, "")
+            value = value.replace(f"${{{ref_key}}}", ref_value)
+
+        secrets_dict[key] = value
+
+    return secrets_dict
+
+
+def export_json(secrets_dict):
+    """Export secrets as JSON."""
+    print(json.dumps(secrets_dict, indent=4))
+
+
+def export_csv(secrets_dict):
+    """Export secrets as CSV."""
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['Key', 'Value'])
+    for key, value in secrets_dict.items():
+        writer.writerow([key, value])
+
+
+def export_yaml(secrets_dict):
+    """Export secrets as YAML."""
+    print(yaml.dump(secrets_dict))
+
+
+def export_toml(secrets_dict):
+    """Export secrets as TOML."""
+    for key, value in secrets_dict.items():
+        print(f'{key} = "{value}"')
+
+
+def export_xml(secrets_dict):
+    """Export secrets as XML."""
+    xml_output = '<Secrets>\n'
+    for key, value in secrets_dict.items():
+        xml_output += f'  <secret name="{key}">{value}</secret>\n'
+    xml_output += '</Secrets>'
+    print(xml_output)
+
+
+def export_dotenv(secrets_dict):
+    """Export secrets in dotenv format."""
+    for key, value in secrets_dict.items():
+        print(f'{key}="{value}"')
+
+
+def export_hcl(secrets_dict):
+    """Export secrets as HCL."""
+    for key, value in secrets_dict.items():
+        print(f'{key} = "{value}"')
+
+
+def export_ini(secrets_dict):
+    """Export secrets as INI."""
+    for key, value in secrets_dict.items():
+        print(f'{key} = {value}')
+
+
+def export_java_properties(secrets_dict):
+    """Export secrets as Java properties file."""
+    for key, value in secrets_dict.items():
+        print(f'{key}={value}')

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -84,34 +84,36 @@ def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None
 def resolve_references(secrets_dict, phase, env_name, phase_app):
     """
     Resolve references in secret values.
-
-    Args:
-        secrets_dict (dict): Dictionary of secrets.
-        phase (Phase): Phase instance.
-        env_name (str): Environment name.
-        phase_app (str): Phase application name.
-
-    Returns:
-        dict: Updated secrets dictionary with resolved references.
     """
     for key, value in secrets_dict.items():
-        # Resolve cross environment references
+        # Track found references to avoid duplicate warnings
+        found_references = set()
+
+        # Resolve cross-environment references
         cross_env_matches = re.findall(cross_env_pattern, value)
         for ref_env, ref_key in cross_env_matches:
+            full_ref = f"{ref_env}.{ref_key}"
+            found_references.add(full_ref)
+
             try:
-                ref_secret = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)[0]
-                value = value.replace(f"${{{ref_env}.{ref_key}}}", ref_secret['value'])
-            except ValueError:
-                print(f"# Warning: Issue with {ref_env} for key {key}. Reference {ref_key} not found.")
+                ref_secrets = phase.get(env_name=ref_env, keys=[ref_key], app_name=phase_app)
+                if ref_secrets:
+                    ref_secret = ref_secrets[0]
+                    value = value.replace(f"${{{full_ref}}}", ref_secret['value'])
+                else:
+                    print(f"# Warning: Secret '{ref_key}' not found in environment '{ref_env}' for key '{key}'.")
+            except ValueError as e:
+                print(f"# Error: Issue with fetching secret '{ref_key}' from environment '{ref_env}' for key '{key}'. {e}")
 
         # Resolve local references
         local_ref_matches = re.findall(local_ref_pattern, value)
         for ref_key in local_ref_matches:
-            if ref_key in secrets_dict:
-                ref_value = secrets_dict[ref_key]
-                value = value.replace(f"${{{ref_key}}}", ref_value)
-            else:
-                print(f"# Warning: Local reference {ref_key} not found for key {key}.")
+            if ref_key not in found_references:
+                if ref_key in secrets_dict:
+                    ref_value = secrets_dict[ref_key]
+                    value = value.replace(f"${{{ref_key}}}", ref_value)
+                else:
+                    print(f"# Warning: Local reference '{ref_key}' not found for key '{key}'.")
 
         secrets_dict[key] = value
 

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -4,6 +4,7 @@ import json
 import csv
 import yaml
 from phase_cli.utils.phase_io import Phase
+import xml.sax.saxutils as saxutils
 from phase_cli.utils.const import cross_env_pattern, local_ref_pattern
 from rich.console import Console
 
@@ -138,7 +139,8 @@ def export_xml(secrets_dict):
     """Export secrets as XML."""
     xml_output = '<Secrets>\n'
     for key, value in secrets_dict.items():
-        xml_output += f'  <secret name="{key}">{value}</secret>\n'
+        escaped_value = saxutils.escape(value)
+        xml_output += f'  <secret name="{key}">{escaped_value}</secret>\n' # Handle escaping
     xml_output += '</Secrets>'
     print(xml_output)
 
@@ -151,14 +153,19 @@ def export_dotenv(secrets_dict):
 
 def export_hcl(secrets_dict):
     """Export secrets as HCL."""
+    print('variable {')
     for key, value in secrets_dict.items():
-        print(f'{key} = "{value}"')
+        escaped_value = value.replace('"', '\\"')  # Escape double quotes
+        print(f'  {key} = {{ default = "{escaped_value}" }}')
+    print('}')
 
 
 def export_ini(secrets_dict):
     """Export secrets as INI."""
+    print("[DEFAULT]")  # Add a default section header
     for key, value in secrets_dict.items():
-        print(f'{key} = {value}')
+        escaped_value = value.replace('%', '%%')  # Escape percent signs
+        print(f'{key} = {escaped_value}')
 
 
 def export_java_properties(secrets_dict):

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -71,7 +71,7 @@ def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None
             export_ini(secrets_dict)
         elif format == 'java_properties':
             export_java_properties(secrets_dict)
-        else:  # Default to dotenv
+        else:
             export_dotenv(secrets_dict)
 
     except ValueError as e:
@@ -153,11 +153,11 @@ def export_dotenv(secrets_dict):
 
 def export_hcl(secrets_dict):
     """Export secrets as HCL."""
-    print('variable {')
     for key, value in secrets_dict.items():
         escaped_value = value.replace('"', '\\"')  # Escape double quotes
-        print(f'  {key} = {{ default = "{escaped_value}" }}')
-    print('}')
+        print(f'variable "{key}" {{')
+        print(f'  default = "{escaped_value}"')
+        print('}\n')
 
 
 def export_ini(secrets_dict):

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -189,7 +189,8 @@ def main ():
         secrets_export_parser.add_argument('--env', type=str, help=env_help)
         secrets_export_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
         secrets_export_parser.add_argument('--tags', type=str, help='🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".')
-
+        secrets_export_parser.add_argument('--format', type=str, default='dotenv', choices=['dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 'java_properties'], help='Specifies the export format. Supported formats: dotenv (default), json, csv, yaml, xml, toml, hcl, ini, java_properties.')
+        
         # Users command
         users_parser = subparsers.add_parser('users', help='👥 Manage users and accounts')
         users_subparsers = users_parser.add_subparsers(dest='users_command', required=True)
@@ -249,7 +250,7 @@ def main ():
             elif args.secrets_command == 'import':
                 phase_secrets_env_import(args.env_file, env_name=args.env, phase_app=args.app)
             elif args.secrets_command == 'export':
-                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, tags=args.tags)
+                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, tags=args.tags, format=args.format)
             elif args.secrets_command == 'update':
                 phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, random_type=args.random, random_length=args.length)
             else:

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -35,4 +35,5 @@ pss_user_pattern = re.compile(r"^pss_user:v(\d+):([a-fA-F0-9]{64}):([a-fA-F0-9]{
 pss_service_pattern = re.compile(r"^pss_service:v(\d+):([a-fA-F0-9]{64}):([a-fA-F0-9]{64}):([a-fA-F0-9]{64}):([a-fA-F0-9]{64})$")
 
 cross_env_pattern = re.compile(r"\$\{(.+?)\.(.+?)\}")
-local_ref_pattern = re.compile(r"\$\{(.+?)\}")
+local_ref_pattern = re.compile(r"\$\{([^.]+?)\}")
+

--- a/tests/secrets_export.py
+++ b/tests/secrets_export.py
@@ -1,0 +1,89 @@
+import pytest
+import json
+import yaml
+import csv
+import io
+import toml
+from xml.etree import ElementTree as ET
+from configparser import ConfigParser
+import hcl2
+from phase_cli.cmd.secrets.export import (
+    export_json, export_csv, export_yaml, export_toml, export_xml, 
+    export_dotenv, export_hcl, export_ini, export_java_properties
+)
+
+secrets_dict = {'AWS_SECRET_ACCESS_KEY': 'aCRAMarEbFC3Q5c24pi7AVMIt6TaCfHeFZ4KCf/a', 'AWS_ACCESS_KEY_ID': 'AKIAIX4ONRSG6ODEFVJA', 'JWT_SECRET': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjMzNjIwMTcxLCJleHAiOjIyMDg5ODUyMDB9.pHnckabbMbwTHAJOkb5Z7G7B4chY6GllJf6K2m96z3A', 'STRIPE_SECRET_KEY': 'sk_test_EeHnL644i6zo4Iyq4v1KdV9H', 'DJANGO_SECRET_KEY': 'wwf*2#86t64!fgh6yav$aoeuo@u2o@fy&*gg76q!&%6x_wbduad', 'DJANGO_DEBUG': 'True', 'POSTGRES_CONNECTION_STRING': 'postgresql://postgres:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM', 'DB_HOST': 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com', 'DB_USER': 'postgres', 'DB_NAME': 'XP1_LM', 'DB_PASSWORD': '6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e', 'DB_PORT': '5432'}
+
+
+
+def test_export_json(capsys):
+    export_json(secrets_dict)
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == secrets_dict
+
+
+def test_export_csv(capsys):
+    export_csv(secrets_dict)
+    captured = capsys.readouterr()
+    reader = csv.reader(io.StringIO(captured.out))
+    header = next(reader)
+    assert header == ['Key', 'Value']
+    for row in reader:
+        assert row[0] in secrets_dict
+        assert row[1] == secrets_dict[row[0]]
+
+
+def test_export_yaml(capsys):
+    export_yaml(secrets_dict)
+    captured = capsys.readouterr()
+    assert yaml.safe_load(captured.out) == secrets_dict
+
+
+def test_export_xml(capsys):
+    export_xml(secrets_dict)
+    captured = capsys.readouterr()
+    root = ET.fromstring(captured.out)
+    for secret in root:
+        assert secret.text == secrets_dict[secret.attrib['name']]
+
+
+def test_export_dotenv(capsys):
+    export_dotenv(secrets_dict)
+    captured = capsys.readouterr()
+    for line in captured.out.strip().split('\n'):
+        key, value = line.split('=', 1)
+        assert value.strip('"') == secrets_dict[key]
+
+
+def test_export_toml(capsys):
+    export_toml(secrets_dict)
+    captured = capsys.readouterr()
+    assert toml.loads(captured.out) == secrets_dict
+
+
+# def test_export_hcl(capsys):
+#     export_hcl(secrets_dict)
+#     captured = capsys.readouterr()
+#     decoded = hcl2.loads(captured.out)
+#     expected_structure = {'variable': []}
+#     for key, value in secrets_dict.items():
+#         expected_structure['variable'].append({key: {'default': value}})
+#     assert decoded == expected_structure
+
+
+def test_export_ini(capsys):
+    export_ini(secrets_dict)
+    captured = capsys.readouterr()
+    parser = ConfigParser()
+    parser.read_string(captured.out)
+    for key in secrets_dict:
+        assert parser['DEFAULT'][key] == secrets_dict[key]
+
+
+def test_export_java_properties(capsys):
+    export_java_properties(secrets_dict)
+    captured = capsys.readouterr()
+    properties = dict(line.split('=', 1) for line in captured.out.strip().split('\n'))
+    for key, value in properties.items():
+        assert value == secrets_dict[key]
+

--- a/tests/secrets_export.py
+++ b/tests/secrets_export.py
@@ -12,9 +12,20 @@ from phase_cli.cmd.secrets.export import (
     export_dotenv, export_hcl, export_ini, export_java_properties
 )
 
-secrets_dict = {'AWS_SECRET_ACCESS_KEY': 'aCRAMarEbFC3Q5c24pi7AVMIt6TaCfHeFZ4KCf/a', 'AWS_ACCESS_KEY_ID': 'AKIAIX4ONRSG6ODEFVJA', 'JWT_SECRET': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjMzNjIwMTcxLCJleHAiOjIyMDg5ODUyMDB9.pHnckabbMbwTHAJOkb5Z7G7B4chY6GllJf6K2m96z3A', 'STRIPE_SECRET_KEY': 'sk_test_EeHnL644i6zo4Iyq4v1KdV9H', 'DJANGO_SECRET_KEY': 'wwf*2#86t64!fgh6yav$aoeuo@u2o@fy&*gg76q!&%6x_wbduad', 'DJANGO_DEBUG': 'True', 'POSTGRES_CONNECTION_STRING': 'postgresql://postgres:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM', 'DB_HOST': 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com', 'DB_USER': 'postgres', 'DB_NAME': 'XP1_LM', 'DB_PASSWORD': '6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e', 'DB_PORT': '5432'}
-
-
+secrets_dict = {
+    'AWS_SECRET_ACCESS_KEY': 'aCRAMarEbFC3Q5c24pi7AVMIt6TaCfHeFZ4KCf/a',
+    'AWS_ACCESS_KEY_ID': 'AKIAIX4ONRSG6ODEFVJA',
+    'JWT_SECRET': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjMzNjIwMTcxLCJleHAiOjIyMDg5ODUyMDB9.pHnckabbMbwTHAJOkb5Z7G7B4chY6GllJf6K2m96z3A',
+    'STRIPE_SECRET_KEY': 'sk_test_EeHnL644i6zo4Iyq4v1KdV9H', 
+    'DJANGO_SECRET_KEY': 'wwf*2#86t64!fgh6yav$aoeuo@u2o@fy&*gg76q!&%6x_wbduad',
+    'DJANGO_DEBUG': 'True', 
+    'POSTGRES_CONNECTION_STRING': 'postgresql://postgres:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM', 
+    'DB_HOST': 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com', 
+    'DB_USER': 'postgres', 
+    'DB_NAME': 'XP1_LM', 
+    'DB_PASSWORD': '6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e', 
+    'DB_PORT': '5432'
+}
 
 def test_export_json(capsys):
     export_json(secrets_dict)
@@ -60,7 +71,7 @@ def test_export_toml(capsys):
     captured = capsys.readouterr()
     assert toml.loads(captured.out) == secrets_dict
 
-
+# TODO: Validate HCL output
 # def test_export_hcl(capsys):
 #     export_hcl(secrets_dict)
 #     captured = capsys.readouterr()

--- a/tests/secrets_export.py
+++ b/tests/secrets_export.py
@@ -71,15 +71,15 @@ def test_export_toml(capsys):
     captured = capsys.readouterr()
     assert toml.loads(captured.out) == secrets_dict
 
-# TODO: Validate HCL output
-# def test_export_hcl(capsys):
-#     export_hcl(secrets_dict)
-#     captured = capsys.readouterr()
-#     decoded = hcl2.loads(captured.out)
-#     expected_structure = {'variable': []}
-#     for key, value in secrets_dict.items():
-#         expected_structure['variable'].append({key: {'default': value}})
-#     assert decoded == expected_structure
+
+def test_export_hcl(capsys):
+    export_hcl(secrets_dict)
+    captured = capsys.readouterr()
+    decoded = hcl2.loads(captured.out)
+    expected_structure = {'variable': []}
+    for key, value in secrets_dict.items():
+        expected_structure['variable'].append({key: {'default': value}})
+    assert decoded == expected_structure
 
 
 def test_export_ini(capsys):


### PR DESCRIPTION
# Added support for the following formats for phase export
- dotenv (.env): Key-value pairs in a simple text format.
- JSON: JavaScript Object Notation, useful for integration with various tools and languages.
- CSV: Comma-Separated Values, a simple text format for tabular data.
- YAML: Human-readable data serialization format, often used for configuration files.
- XML: Extensible Markup Language, suitable for complex data structures.
- TOML: Tom's Obvious, Minimal Language, a readable configuration file format.
- HCL: HashiCorp Configuration Language, used in HashiCorp tools like Terraform.
- INI: A simple format often used for configuration files.
- Java Properties: Key-value pair format commonly used in Java applications.

```fish
Securely manage and sync environment variables with Phase.

         ⢠⠔⠋⣳⣖⠚⣲⢖⠙⠳⡄                          
        ⡴⠉⢀⡼⠃⢘⣞⠁⠙⡆ ⠘⡆                         
      ⢀⡜⠁⢠⠞ ⢠⠞⠸⡆ ⠹⡄ ⠹⡄                        
     ⢀⠞ ⢠⠏ ⣠⠏  ⢳  ⢳  ⢧                        
    ⢠⠎ ⣠⠏ ⣰⠃   ⠈⣇ ⠘⡇ ⠘⡆                       
   ⢠⠏ ⣰⠇ ⣰⠃     ⢺⡀ ⢹  ⢽                       
  ⢠⠏ ⣰⠃ ⣰⠃       ⣇ ⠈⣇ ⠘⡇                      
 ⢠⠏ ⢰⠃ ⣰⠃        ⢸⡀ ⢹⡀ ⢹                      
⢠⠏ ⢰⠃ ⣰⠃          ⣇ ⠈⣇ ⠈⡇                     
⠛⠒⠚⠛⠒⠓⠚⠒⠒⠓⠒⠓⠚⠒⠓⠚⠒⠓⢻⡒⠒⢻⡒⠒⢻⡒⠒⠒⠒⠒⠒⠒⠒⠒⠒⣲⠒⠒⣲⠒⠒⡲    
                   ⢧  ⢧ ⠈⣇        ⢠⠇ ⣰⠃ ⣰⠃    
                   ⠘⡆ ⠘⡆ ⠸⡄      ⣠⠇ ⣰⠃ ⣴⠃     
                    ⠹⡄ ⠹⡄ ⠹⡄    ⡴⠃⢀⡼⠁⢀⡼⠁      
                     ⠙⣆ ⠙⣆ ⠹⣄ ⣠⠎⠁⣠⠞ ⡤⠏        
                      ⠈⠳⢤⣈⣳⣤⣼⣹⢥⣰⣋⡥⡴⠊⠁         

positional arguments:
  keys         List of keys separated by space

options:
  -h, --help   show this help message and exit
  --env ENV    Environment name eg. dev, staging, production
  --app APP    The name of your Phase application. Optional: If you don't have a .phase.json file in your project directory or simply want to override it.
  --tags TAGS  🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".
  --format {dotenv,json,csv,yaml,xml,toml,hcl,ini,java_properties}
               Specifies the export format. Supported formats: dotenv (default), json, csv, yaml, xml, toml, hcl, ini, java_properties.

```

Examples:

```fish
λ phase secrets export POSTGRES_CONNECTION_STRING --format json
{
    "POSTGRES_CONNECTION_STRING": "postgresql://prostgres_prod_user:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM"
}
```
```fish
λ phase secrets export POSTGRES_CONNECTION_STRING --format hcl
variable "AWS_SECRET_ACCESS_KEY" {
  default = "aCRAMarEbFC3Q5c24pi7AVMIt6TaCfHeFZ4KCf/a"
}

variable "AWS_ACCESS_KEY_ID" {
  default = "AKIAIX4ONRSG6ODEFVJA"
}

variable "JWT_SECRET" {
  default = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjMzNjIwMTcxLCJleHAiOjIyMDg5ODUyMDB9.pHnckabbMbwTHAJOkb5Z7G7B4chY6GllJf6K2m96z3A"
}

variable "STRIPE_SECRET_KEY" {
  default = "sk_test_EeHnL644i6zo4Iyq4v1KdV9H"
}

variable "DJANGO_SECRET_KEY" {
  default = "wwf*2#86t64!fgh6yav$aoeuo@u2o@fy&*gg76q!&%6x_wbduad"
}

variable "DJANGO_DEBUG" {
  default = "True"
}

variable "POSTGRES_CONNECTION_STRING" {
  default = "postgresql://prostgres_prod_user:6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e@mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com:5432/XP1_LM"
}

variable "DB_HOST" {
  default = "mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com"
}

variable "DB_USER" {
  default = "postgres_user"
}

variable "DB_NAME" {
  default = "XP1_LM"
}

variable "DB_PASSWORD" {
  default = "6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e"
}

variable "DB_PORT" {
  default = "5432"
}

```