### PR TITLE
feat: use \u200A to space emoji unicode instead of '`'

### DIFF
--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -42,7 +42,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
     if random_type:
         # Check if length is specified for key128 or key256
         if random_type in ['key128', 'key256'] and random_length != 32:
-            print("⚠️  Warning: The length argument is ignored for 'key128' and 'key256'. Using default lengths.")
+            print("⚠️\u200A Warning: The length argument is ignored for 'key128' and 'key256'. Using default lengths.")
 
         try:
             value = generate_random_secret(random_type, random_length)

--- a/phase_cli/cmd/users/whoami.py
+++ b/phase_cli/cmd/users/whoami.py
@@ -26,9 +26,9 @@ def phase_users_whoami():
             return
 
         # Print the default user details
-        print(f"✉️` Email: {default_user['email']}")
+        print(f"✉️\u200A Email: {default_user['email']}")
         print(f"🙋 User ID: {default_user['id']}")
-        print(f"☁️` Host: {default_user['host']}")
+        print(f"☁️\u200A Host: {default_user['host']}")
 
     except FileNotFoundError:
         print(f"Config file not found at {CONFIG_FILE}.")

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -92,7 +92,7 @@ def main ():
         run_parser.add_argument('--tags', type=str, help=tag_help)
 
         # Secrets command
-        secrets_parser = subparsers.add_parser('secrets', help='🗝️` Manage your secrets')
+        secrets_parser = subparsers.add_parser('secrets', help='🗝️\u200A Manage your secrets')
         secrets_subparsers = secrets_parser.add_subparsers(dest='secrets_command', required=True)
 
         # Secrets list command
@@ -173,7 +173,7 @@ def main ():
                                         help='🔢 Specify the length of the random value. Applicable for types other than key128 and key256. Default is 32. Example usage: --length 16')
 
         # Secrets delete command
-        secrets_delete_parser = secrets_subparsers.add_parser('delete', help='🗑️` Delete a secret')
+        secrets_delete_parser = secrets_subparsers.add_parser('delete', help='🗑️\u200A Delete a secret')
         secrets_delete_parser.add_argument('keys', nargs='*', help='Keys to be deleted')
         secrets_delete_parser.add_argument('--env', type=str, help=env_help)
         secrets_delete_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
@@ -207,7 +207,7 @@ def main ():
         keyring_parser = users_subparsers.add_parser('keyring', help='🔐 Display information about the Phase keyring')
 
         # Web command
-        web_parser = subparsers.add_parser('console', help='🖥️` Open the Phase Console in your browser')
+        web_parser = subparsers.add_parser('console', help='🖥️\u200A Open the Phase Console in your browser')
 
         # Check if the operating system is Linux before adding the update command
         if sys.platform == "linux":

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -258,7 +258,7 @@ def phase_get_context(user_data, app_name=None, env_name=None):
         environment = next((env for env in application["environment_keys"] if env_name.lower() in env["environment"]["name"].lower()), None)
 
         if not environment:
-            raise ValueError(f"⚠️  Warning: The environment '{env_name}' either does not exist or you do not have access to it.")
+            raise ValueError(f"⚠️\u200A Warning: The environment '{env_name}' either does not exist or you do not have access to it.")
 
         return application["id"], environment["environment"]["id"], environment["identity_key"]
     


### PR DESCRIPTION
Use unicode hair space `\u200A` instead of ' ` '  to space emojies.

Needs testing on:
- Windows (powershell, bash, gitbash, WSL etc.)
- MacOS terminal