### PR TITLE
Fix  cross env edge case

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.11.1
+pkgver=1.11.2
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,6 +1,6 @@
 import os
 import re
-__version__ = "1.11.1"
+__version__ = "1.11.2"
 __ph_version__ = "v1"
 
 description = "Securely manage and sync environment variables with Phase."


### PR DESCRIPTION
This PR fixes `list index out of range` error when referring a non existing secret in a valid cross environment.

Example:
Secret: DEBUG_PROD - doesn't exist
Environment: production - exits

Secret: DEBUG - exits and set to ${production.DEBUG_PROD}
Environment: development - exists

```fish
λ phase run --env development "printenv | grep DEBUG"
[15:05:42] ⚠️  Warning: Secret 'DEBUG_PROD' not found in environment 'production'. Ignoring...                                                                            
DEBUG=
```