### PR TITLE
fix: resolver fallback behavior

### DIFF
--- a/phase_cli/exceptions.py
+++ b/phase_cli/exceptions.py
@@ -1,0 +1,3 @@
+class EnvironmentNotFoundException(Exception):
+    def __init__(self, env_name):
+        super().__init__(f"⚠️\u200A Warning: The environment '{env_name}' either does not exist or you do not have access to it.")

--- a/phase_cli/exceptions.py
+++ b/phase_cli/exceptions.py
@@ -1,3 +1,4 @@
 class EnvironmentNotFoundException(Exception):
     def __init__(self, env_name):
         super().__init__(f"⚠️\u200A Warning: The environment '{env_name}' either does not exist or you do not have access to it.")
+        

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -4,6 +4,7 @@ import subprocess
 import webbrowser
 import getpass
 import json
+from phase_cli.exceptions import EnvironmentNotFoundException
 from rich.table import Table
 from rich.tree import Tree
 from rich.console import Console
@@ -298,7 +299,7 @@ def phase_get_context(user_data, app_name=None, env_name=None):
         environment = next((env for env in application["environment_keys"] if env_name.lower() in env["environment"]["name"].lower()), None)
 
         if not environment:
-            raise ValueError(f"⚠️\u200A Warning: The environment '{env_name}' either does not exist or you do not have access to it.")
+            raise EnvironmentNotFoundException(env_name)
 
         # Return application name, application ID, environment name, environment ID, and public key
         return (application["name"], application["id"], environment["environment"]["name"], environment["environment"]["id"], environment["identity_key"])

--- a/phase_cli/utils/secret_referencing.py
+++ b/phase_cli/utils/secret_referencing.py
@@ -87,6 +87,7 @@ def resolve_secret_reference(ref: str, current_env_name: str, phase: 'Phase') ->
     try:
         secrets = phase.get(env_name=env_name, keys=[key_name], path=path)
     except EnvironmentNotFoundException:
+        # Fallback to the current env if the named env cannot be resolved
         secrets = phase.get(env_name=current_env_name, keys=[key_name], path=path)
 
     
@@ -95,7 +96,7 @@ def resolve_secret_reference(ref: str, current_env_name: str, phase: 'Phase') ->
             # Return the secret value if found.
             return secret["value"]
     
-    # Return the secrety value as is if no reference could be resolved
+    # Return the secret value as is if no reference could be resolved
     return ref
     
     


### PR DESCRIPTION
* Throw an `EnvironmentNotFound` exception when the named environment is not found or cannot be accessed
* Return a secret value as is, if a reference cannot be resolved