### PR TITLE
fix: removed progress spinner and export status

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.13.0
+pkgver=1.13.1
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.13.0"
+__version__ = "1.13.1"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."


### PR DESCRIPTION
This PR reverts the previous decision to add a spinner and secret export stats. So commands like `docker run --rm --env-file <(phase secrets export --app application) alpine:latest printenv` are not broken.