### PR TITLE
Added multiple users, organizations and instance support

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.13.1
+pkgver=1.14.0
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/cmd/auth.py
+++ b/phase_cli/cmd/auth.py
@@ -120,19 +120,7 @@ def phase_auth(mode="webauth"):
     Returns:
         None
     """
-
-    # Check if the user is already authenticated
-    config_file_path = os.path.join(PHASE_SECRETS_DIR, 'config.json')
-    if os.path.exists(config_file_path):
-        with open(config_file_path, 'r') as f:
-            config_data = json.load(f)
-            default_user_id = config_data.get('default-user')
-            for user in config_data.get('phase-users', []):
-                if user.get('id') == default_user_id:
-                    print(f"🙋 You are currently logged in as: \033[1;34m{user.get('email')}\033[0m")
-                    print("To switch accounts: '\033[1mphase users logout --purge\033[0m && \033[1mphase auth\033[0m'")
-                    return
-                
+             
     server = None
     try:
         # Choose the authentication mode: webauth (default) or token-based.
@@ -236,8 +224,14 @@ def phase_auth(mode="webauth"):
             user_id = user_data["user_id"]
             offline_enabled = user_data["offline_enabled"]
             wrapped_key_share = None if not offline_enabled else user_data["wrapped_key_share"]
-            organization_id = user_data["organisation"]["id"]
-            organization_name = user_data["organisation"]["name"]
+
+            # Note: Phase Console v2.14.0 doesn't return organization context
+            if 'organisation' in user_data and user_data['organisation']:
+                organization_id = user_data["organisation"]["id"]
+                organization_name = user_data["organisation"]["name"]
+            else:
+                organization_id = None
+                organization_name = None
 
             # Save the credentials in the Phase keyring
             keyring.set_password(f"phase-cli-user-{user_id}", "pss", personal_access_token)

--- a/phase_cli/cmd/auth.py
+++ b/phase_cli/cmd/auth.py
@@ -236,6 +236,8 @@ def phase_auth(mode="webauth"):
             user_id = user_data["user_id"]
             offline_enabled = user_data["offline_enabled"]
             wrapped_key_share = None if not offline_enabled else user_data["wrapped_key_share"]
+            organization_id = user_data["organisation"]["id"]
+            organization_name = user_data["organisation"]["name"]
 
             # Save the credentials in the Phase keyring
             keyring.set_password(f"phase-cli-user-{user_id}", "pss", personal_access_token)
@@ -248,7 +250,10 @@ def phase_auth(mode="webauth"):
                         "email": user_email,
                         "host": PHASE_API_HOST,
                         "id": user_id,
+                        "organization_id": organization_id,
+                        "organization_name": organization_name,
                         "wrapped_key_share": wrapped_key_share
+
                     }
                 ]
             }

--- a/phase_cli/cmd/users/logout.py
+++ b/phase_cli/cmd/users/logout.py
@@ -1,28 +1,58 @@
+import json
 import os
 import sys
 import shutil
 import keyring
-from phase_cli.utils.const import PHASE_SECRETS_DIR
+from phase_cli.utils.const import PHASE_SECRETS_DIR, CONFIG_FILE
 from phase_cli.utils.misc import get_default_user_id
 
+def save_config(config_data):
+    """Saves the updated configuration data to the config file."""
+    with open(CONFIG_FILE, 'w') as f:
+        json.dump(config_data, f, indent=4)
+
 def phase_cli_logout(purge=False):
+    """Log out from the phase CLI. Deletes credentials from keyring and optionally purges all local data."""
+    config_file_path = CONFIG_FILE
+
     if purge:
-        all_user_ids = get_default_user_id(all_ids=True)
-        for user_id in all_user_ids:
-            keyring.delete_password(f"phase-cli-user-{user_id}", "pss")
+        try:
+            all_user_ids = get_default_user_id(all_ids=True)
+            for user_id in all_user_ids:
+                keyring.delete_password(f"phase-cli-user-{user_id}", "pss")
 
-        # Delete PHASE_SECRETS_DIR if it exists
-        if os.path.exists(PHASE_SECRETS_DIR):
-            shutil.rmtree(PHASE_SECRETS_DIR)
-            print("Logged out and purged all local data.")
-        else:
-            print("No local data found to purge.")
-
+            # Delete PHASE_SECRETS_DIR if it exists
+            if os.path.exists(PHASE_SECRETS_DIR):
+                shutil.rmtree(PHASE_SECRETS_DIR)
+                print("Logged out and purged all local data.")
+            else:
+                print("No local data found to purge.")
+        except ValueError as e:
+            print(e)
+            sys.exit(1)
     else:
-        # For the default user
-        pss = keyring.get_password("phase", "pss")
-        if not pss:
+        # Load the existing config to update it
+        if not os.path.exists(config_file_path):
             print("No configuration found. Please run 'phase auth' to set up your configuration.")
             sys.exit(1)
-        keyring.delete_password("phase", "pss")
-        print("Logged out successfully.")
+
+        with open(config_file_path, 'r') as f:
+            config_data = json.load(f)
+
+        # Identify the default user and remove their credentials
+        default_user_id = get_default_user_id()
+        if default_user_id:
+            keyring.delete_password(f"phase-cli-user-{default_user_id}", "pss")
+            # Remove the default user from the config
+            config_data['phase-users'] = [user for user in config_data['phase-users'] if user['id'] != default_user_id]
+            # If there are no users left, remove the default user ID as well
+            if not config_data['phase-users']:
+                config_data.pop('default-user', None)
+            else:
+                # Update the default user to the next available user, if any
+                config_data['default-user'] = config_data['phase-users'][0]['id']
+
+            save_config(config_data)
+            print("Logged out successfully.")
+        else:
+            print("No default user in configuration found. Please run 'phase auth' to set up your configuration.")

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -20,10 +20,16 @@ def switch_user():
         return
 
     # Prepare user choices, including a visual separator as a title.
-    user_choices = [Separator("✉️\u200A Email, 🏢 Organization, ☁️\u200A Phase Host")] + [
-        f"{user['email']}, {user.get('organization_name', 'N/A')}, {user['host']}"
+    # Also, create a mapping for the partial UUID to the full UUID.
+    uuid_mapping = {}
+    user_choices = [Separator("✉️\u200A Email, 🏢 Organization, ☁️\u200A Phase Host, 🆔 User ID")] + [
+        f"{user['email']}, {user.get('organization_name', 'N/A')}, {user['host']}, {user['id'][:8]}"
         for user in config_data['phase-users']
     ]
+    
+    for user in config_data['phase-users']:
+        partial_uuid = user['id'][:8]
+        uuid_mapping[partial_uuid] = user['id']
 
     try:
         while True:
@@ -36,14 +42,13 @@ def switch_user():
             if selected is None:
                 break
 
+            # Extract the UUID part from the selection.
+            uuid_selected = selected.split(", ")[-1]
 
-            email_selected = selected.split(", ")[0]
-
-            # Identify and switch to the selected user by their email.
-            selected_user_id = next((user['id'] for user in config_data['phase-users'] if user['email'] == email_selected), None)
-
-            if selected_user_id:
-                config_data['default-user'] = selected_user_id
+            # Use the full UUID from the mapping to identify and switch to the selected user.
+            full_uuid = uuid_mapping.get(uuid_selected, None)
+            if full_uuid:
+                config_data['default-user'] = full_uuid
                 save_config(config_data)
                 print(f"Switched to user 🙋: {selected}")
                 break

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -1,0 +1,59 @@
+import json
+import os
+from questionary import select, Separator
+from phase_cli.utils.const import CONFIG_FILE
+
+def load_config():
+    if not os.path.exists(CONFIG_FILE):
+        print("Configuration file does not exist.")
+        return None
+    with open(CONFIG_FILE, 'r') as f:
+        return json.load(f)
+
+def save_config(config_data):
+    with open(CONFIG_FILE, 'w') as f:
+        json.dump(config_data, f, indent=4)
+
+def switch_user():
+    config_data = load_config()
+    if not config_data:
+        return
+
+    # Prepend a 'title choice' with a Separator for visual effect.
+    user_choices = [
+        Separator("✉️\u200A Email - 🏢 Organization - 🌐 Host")
+    ]
+    
+    user_choices += [
+        f"{user['email']}, {user.get('organization_name', 'N/A')}, {user['host']}"
+        for user in config_data['phase-users']
+    ]
+
+    while True:
+        selected = select(
+            "Choose a user to switch to:",
+            choices=user_choices
+        ).ask()
+
+        # Re-show the selection prompt if the 'title choice' is selected.
+        if selected.startswith("✉️ Email, 🏢 Org, 🌐 Host"):
+            continue  # This effectively ignores the selection and prompts again.
+
+        # Extract email from the selected choice as the unique identifier
+        email_selected = selected.split(", ")[0].replace("✉️ ", "")
+
+        # Find the ID of the selected user by email
+        selected_user_id = None
+        for user in config_data['phase-users']:
+            if user['email'] == email_selected:
+                selected_user_id = user['id']
+                break
+
+        if selected_user_id:
+            config_data['default-user'] = selected_user_id
+            save_config(config_data)
+            print(f"Switched to user: {selected}")
+            break  # Exit after successful switch
+        else:
+            print("User switch failed.")
+            break  # Or consider retrying

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -22,8 +22,8 @@ def switch_user():
     # Prepare user choices, including a visual separator as a title.
     # Also, create a mapping for the partial UUID to the full UUID.
     uuid_mapping = {}
-    user_choices = [Separator("✉️\u200A Email, 🏢 Organization, ☁️\u200A Phase Host, 🆔 User ID")] + [
-        f"{user['email']}, {user.get('organization_name', 'N/A')}, {user['host']}, {user['id'][:8]}"
+    user_choices = [Separator("🏢 Organization, ✉️\u200A Email, ☁️\u200A Phase Host, 🆔 User ID")] + [
+        f"{user.get('organization_name', 'N/A')}, {user['email']}, {user['host']}, {user['id'][:8]}"
         for user in config_data['phase-users']
     ]
     

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -20,7 +20,7 @@ def switch_user():
         return
 
     # Prepare user choices, including a visual separator as a title.
-    user_choices = [Separator("✉️\u200A Email - 🏢 Organization - 🌐 Phase Host")] + [
+    user_choices = [Separator("✉️\u200A Email - 🏢 Organization - ☁️\u200A Phase Host")] + [
         f"{user['email']}, {user.get('organization_name', 'N/A')}, {user['host']}"
         for user in config_data['phase-users']
     ]
@@ -45,7 +45,7 @@ def switch_user():
             if selected_user_id:
                 config_data['default-user'] = selected_user_id
                 save_config(config_data)
-                print(f"Switched to user: {selected}")
+                print(f"Switched to user 🙋: {selected}")
                 break
             else:
                 print("User switch failed.")

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -5,7 +5,7 @@ from phase_cli.utils.const import CONFIG_FILE
 
 def load_config():
     if not os.path.exists(CONFIG_FILE):
-        print("Configuration file does not exist.")
+        print("No configuration found. Please run 'phase auth' to set up your configuration.")
         return None
     with open(CONFIG_FILE, 'r') as f:
         return json.load(f)
@@ -19,41 +19,36 @@ def switch_user():
     if not config_data:
         return
 
-    # Prepend a 'title choice' with a Separator for visual effect.
-    user_choices = [
-        Separator("✉️\u200A Email - 🏢 Organization - 🌐 Host")
-    ]
-    
-    user_choices += [
+    # Prepare user choices, including a visual separator as a title.
+    user_choices = [Separator("✉️\u200A Email - 🏢 Organization - 🌐 Phase Host")] + [
         f"{user['email']}, {user.get('organization_name', 'N/A')}, {user['host']}"
         for user in config_data['phase-users']
     ]
 
-    while True:
-        selected = select(
-            "Choose a user to switch to:",
-            choices=user_choices
-        ).ask()
+    try:
+        while True:
+            selected = select(
+                "Choose a user to switch to:",
+                choices=user_choices
+            ).ask()
 
-        # Re-show the selection prompt if the 'title choice' is selected.
-        if selected.startswith("✉️ Email, 🏢 Org, 🌐 Host"):
-            continue  # This effectively ignores the selection and prompts again.
-
-        # Extract email from the selected choice as the unique identifier
-        email_selected = selected.split(", ")[0].replace("✉️ ", "")
-
-        # Find the ID of the selected user by email
-        selected_user_id = None
-        for user in config_data['phase-users']:
-            if user['email'] == email_selected:
-                selected_user_id = user['id']
+            # Break if selection is cancelled (Ctrl+C or escape)
+            if selected is None:
                 break
 
-        if selected_user_id:
-            config_data['default-user'] = selected_user_id
-            save_config(config_data)
-            print(f"Switched to user: {selected}")
-            break  # Exit after successful switch
-        else:
-            print("User switch failed.")
-            break  # Or consider retrying
+
+            email_selected = selected.split(", ")[0]
+
+            # Identify and switch to the selected user by their email.
+            selected_user_id = next((user['id'] for user in config_data['phase-users'] if user['email'] == email_selected), None)
+
+            if selected_user_id:
+                config_data['default-user'] = selected_user_id
+                save_config(config_data)
+                print(f"Switched to user: {selected}")
+                break
+            else:
+                print("User switch failed.")
+                break
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -20,7 +20,7 @@ def switch_user():
         return
 
     # Prepare user choices, including a visual separator as a title.
-    user_choices = [Separator("✉️\u200A Email - 🏢 Organization - ☁️\u200A Phase Host")] + [
+    user_choices = [Separator("✉️\u200A Email, 🏢 Organization, ☁️\u200A Phase Host")] + [
         f"{user['email']}, {user.get('organization_name', 'N/A')}, {user['host']}"
         for user in config_data['phase-users']
     ]

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -23,7 +23,7 @@ def switch_user():
     # Also, create a mapping for the partial UUID to the full UUID.
     uuid_mapping = {}
     user_choices = [Separator("🏢 Organization, ✉️\u200A Email, ☁️\u200A Phase Host, 🆔 User ID")] + [
-        f"{user.get('organization_name', 'N/A')}, {user['email']}, {user['host']}, {user['id'][:8]}"
+        f"{user.get('organization_name', 'N/A') if user.get('organization_name') else 'N/A'}, {user['email']}, {user['host']}, {user['id'][:8]}"
         for user in config_data['phase-users']
     ]
     

--- a/phase_cli/cmd/users/whoami.py
+++ b/phase_cli/cmd/users/whoami.py
@@ -28,6 +28,7 @@ def phase_users_whoami():
         # Print the default user details
         print(f"✉️\u200A Email: {default_user['email']}")
         print(f"🙋 User ID: {default_user['id']}")
+        print(f"🏢 Organization: {default_user['organization_name']}")
         print(f"☁️\u200A Host: {default_user['host']}")
 
     except FileNotFoundError:

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -8,6 +8,7 @@ from phase_cli.cmd.open_console import phase_open_console
 from phase_cli.cmd.open_docs import phase_open_docs
 from phase_cli.cmd.update import phase_cli_update
 from phase_cli.cmd.users.whoami import phase_users_whoami
+from phase_cli.cmd.users.switch import switch_user
 from phase_cli.cmd.users.keyring import show_keyring_info
 from phase_cli.cmd.users.logout import phase_cli_logout
 from phase_cli.cmd.run import phase_run_inject
@@ -220,6 +221,9 @@ def main ():
         # Users whoami command
         whoami_parser = users_subparsers.add_parser('whoami', help='🙋 See details of the current user')
 
+        # Users switch command - new addition
+        switch_parser = users_subparsers.add_parser('switch', help='🪄\u200A Switch between Phase users, orgs and hosts')
+
         # Users logout command
         logout_parser = users_subparsers.add_parser('logout', help='🏃 Logout from phase-cli')
         logout_parser.add_argument('--purge', action='store_true', help='Purge all local data')
@@ -257,6 +261,8 @@ def main ():
         elif args.command == 'users':
             if args.users_command == 'whoami':
                 phase_users_whoami()
+            elif args.users_command == 'switch':
+                switch_user()
             elif args.users_command == 'logout':
                 phase_cli_logout(args.purge)
             elif args.users_command == 'keyring':

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.13.1"
+__version__ = "1.14.0"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -271,6 +271,7 @@ def phase_get_context(user_data, app_name=None, env_name=None):
         with open(PHASE_ENV_CONFIG, 'r') as f:
             config_data = json.load(f)
         default_env_name = config_data.get("defaultEnv")
+        app_name_from_config = config_data.get("phaseApp")
         app_id = config_data.get("appId")
     except FileNotFoundError:
         default_env_name = "Development"
@@ -291,7 +292,7 @@ def phase_get_context(user_data, app_name=None, env_name=None):
         elif app_id:
             application = next((app for app in user_data["apps"] if app["id"] == app_id), None)
             if not application:
-                raise ValueError(f"No application found with the ID '{app_id}'.")
+                raise ValueError(f"🔍 No application found with the name '{app_name_from_config}' and ID: '{app_id}'.")
         else:
             raise ValueError("🤔 No application context provided. Please run 'phase init' or pass the '--app' flag followed by your application name.")
 


### PR DESCRIPTION
This PR adds the ability to authenticate seamlessly switch between different Phase users, organizations and instances.

Notes: 
- Make sure you log out the Phase CLI before testing (phase users logout --purge)
- Make sure you are running https://github.com/phasehq/console/pull/211 version of the Phase Console

Things to test:
- Authentication: phase auth (log into different users, orgs instances)
- Switch users: phase users switch (switch in between them)
- phase secrets CRUD (test access to secrets)