### PR TITLE
Improve console

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.15.0
+pkgver=1.17.0
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/cmd/open_console.py
+++ b/phase_cli/cmd/open_console.py
@@ -1,14 +1,31 @@
 import os
 import json
 import webbrowser
-from phase_cli.utils.misc import get_default_user_host
+from phase_cli.utils.misc import get_default_user_host, get_default_user_org, open_browser
+from phase_cli.utils.const import PHASE_SECRETS_DIR
 
 def phase_open_console():
-    """
-    Open the Phase console in a web browser based on environment variables or local configuration.
-    """
+    """Opens the Phase console in a web browser based on the default organization, application ID, and possibly the environment ID."""
     try:
-        url = get_default_user_host()
-        webbrowser.open(url)
-    except ValueError as e:
+        url_base = get_default_user_host()
+        config_file_path = os.path.join(PHASE_SECRETS_DIR, 'config.json')
+        org_name = get_default_user_org(config_file_path)
+        
+        phase_env_config_path = os.path.join(os.getcwd(), ".phase.json")
+        if os.path.exists(phase_env_config_path):
+            with open(phase_env_config_path, 'r') as file:
+                config = json.load(file)
+                app_id = config.get("appId")
+                version = int(config.get("version", "1"))  # Default to version 1 if not specified
+                
+                if version >= 2 and "envId" in config:
+                    env_id = config.get("envId")
+                    url = f"{url_base}/{org_name}/apps/{app_id}/environments/{env_id}"
+                else:
+                    url = f"{url_base}/{org_name}/apps/{app_id}"
+        else:
+            url = url_base
+        
+        open_browser(url)
+    except Exception as e:
         print(f"Error opening Phase console: {e}")

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.15.0"
+__version__ = "1.17.0"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -250,6 +250,18 @@ def get_default_user_id(all_ids=False) -> Union[str, List[str]]:
         return config_data.get("default-user")
 
 
+def get_default_user_org(config_file_path):
+    """Extracts the organization name of the default user from a JSON config file."""
+    if os.path.exists(config_file_path):
+        with open(config_file_path, 'r') as file:
+            config = json.load(file)
+            default_user_id = config.get("default-user")
+            for user in config.get("phase-users", []):
+                if user["id"] == default_user_id:
+                    return user["organization_name"]
+    raise ValueError("Configuration file missing or default user not found.")
+
+
 def get_default_user_token() -> str:
     """
     Fetch the default user's personal access token from the config file in PHASE_SECRETS_DIR.


### PR DESCRIPTION
The `phase console` command now will follow the following behavior:
- If no phase config (phase.json) is present - simply open the PHASE_HOST
- If a phase config (.phase.json) v1 is present - open the application environments windows
- If a phase config (.phase.json) v2 is present - open the default application environments secret screen


Partially depends on: https://github.com/phasehq/cli/pull/132 which introduces phase config v2.