### PR TITLE
Fix: secret values from overflowing in the table

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.15.0
+pkgver=1.17.2
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.15.0"
+__version__ = "1.17.2"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -66,7 +66,7 @@ def censor_secret(secret, max_length):
 
     # Check for column width and truncate if necessary
     if len(censored) > max_length:
-        return censored[:max_length - 3]
+        return censored[:max_length - 6]
     
     return censored
 


### PR DESCRIPTION


Before:
![image](https://github.com/phasehq/cli/assets/85357445/b1783917-ab6a-4bcb-b843-5e50e008b6d0)

After:
![image](https://github.com/phasehq/cli/assets/85357445/4f6e59c3-2fe1-4e5f-a91b-09590c7e2c76)
