### PR TITLE
Fix: personal secret overrides

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.15.0
+pkgver=1.17.3
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.15.0"
+__version__ = "1.17.3"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/phase_io.py
+++ b/phase_cli/utils/phase_io.py
@@ -192,14 +192,17 @@ class Phase:
 
         results = []
         for secret in secrets_data:
+            # Check if a tag filter is applied and if the secret has the correct tags.
             if tag and not tag_matches(secret.get("tags", []), tag):
                 continue
 
             secret_id = secret["id"]
             override = secret.get("override")
-            use_override = override and override.get("secret") == secret_id and override.get("is_active")
+            # Check if the override exists and is active.
+            use_override = override and override.get("is_active")
 
             key_to_decrypt = secret["key"]
+            # Select the correct value based on override status.
             value_to_decrypt = override["value"] if use_override else secret["value"]
             comment_to_decrypt = secret["comment"]
 
@@ -218,6 +221,7 @@ class Phase:
                 "environment": env_name 
             }
 
+            # Only add the secret to results if the requested keys are not specified or the decrypted key is one of the requested keys.
             if not keys or decrypted_key in keys:
                 results.append(result)
 


### PR DESCRIPTION
This PR fixes an issue where the value of personal secrets was not being returned in the following commands:
- phase run
- phase secrets list
- phase secrets export
- phase secrets get

How to test:
- Activate personal secret override in the Phase Console and retrieve the secrets via the Phase CLI and check the value 
- De-activate personal secret override (while a value is saved) in he Phase Console and retrieve the secrets via the Phase CLI and check the value