### PR TITLE
Improve secret key processing

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.17.3
+pkgver=1.17.4
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -29,18 +29,6 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         # Replace spaces in the key with underscores
         key = key.replace(' ', '_').upper()
 
-    # Check if the secret already exists
-    try:
-        secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app, path=path)
-        secret_data = next((secret for secret in secrets_data if secret["key"] == key), None)
-        if secret_data:
-            # Updated to include path in the optional flags message
-            print(f"🗝️  Secret with key '{key}' already exists at path '{path}'. Use 'phase secrets update' to change it's value.")
-            return
-    except ValueError as e:
-        console.log(f"Error: {e}")
-        return
-
     # Generate a random value or get value from user
     if random_type:
         # Check if length is specified for key128 or key256

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -4,12 +4,10 @@ from phase_cli.utils.phase_io import Phase
 from phase_cli.cmd.secrets.list import phase_list_secrets
 from phase_cli.utils.crypto import generate_random_secret
 from rich.console import Console
-from typing import List, Tuple
-import requests
 
 def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=None, random_length=None, path='/'):
     """
-    Creates a new secret, encrypts it, and sync it with the Phase, with support for specifying a path.
+    Creates a new secret, encrypts it, and syncs it with the Phase, with support for specifying a path.
 
     Args:
         key (str, optional): The key of the new secret. Defaults to None.
@@ -26,8 +24,10 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
 
     # If the key is not passed as an argument, prompt user for input
     if key is None:
-        key = input("🗝️  Please enter the key: ")
-    key = key.upper()
+        key = input("🗝️\u200A Please enter the key: ")
+
+        # Replace spaces in the key with underscores
+        key = key.replace(' ', '_').upper()
 
     # Check if the secret already exists
     try:
@@ -60,7 +60,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
             value = sys.stdin.read().strip()
 
     try:
-        # Encrypt and send secret to the backend using the `create` method with path support
+        # Encrypt and POST secret to the backend using phase create
         response = phase.create(key_value_pairs=[(key, value)], env_name=env_name, app_name=phase_app, path=path)
 
         # Check the response status code

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -22,8 +22,12 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
     phase = Phase()
     console = Console()
     
-    # Convert the key to uppercase
-    key = key.upper()
+    # If the key is not passed as an argument, prompt user for input
+    if key is None:
+        key = input("🗝️\u200A Please enter the key: ")
+
+        # Replace spaces in the key with underscores
+        key = key.replace(' ', '_').upper()
 
     # Generate a random value or get value from user
     if random_type:
@@ -46,7 +50,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
     try:
         response = phase.update(env_name=env_name, key=key, value=new_value, app_name=phase_app, source_path=source_path, destination_path=destination_path)
         if response == "Success":
-            print("Successfully updated the secret.")
+            print("✅ Successfully updated the secret.")
             # Optionally, list secrets after update to confirm the change
             phase_list_secrets(show=False, phase_app=phase_app, env_name=env_name, path=destination_path or source_path)
         else:

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -25,17 +25,6 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
     # Convert the key to uppercase
     key = key.upper()
 
-    # Check if the secret exists in the specified source path
-    try:
-        secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app, path=source_path)
-        secret_data = next((secret for secret in secrets_data if secret["key"] == key), None)
-        if not secret_data:
-            print(f"🔍 No secret found for key: {key} in path: {source_path}")
-            return
-    except ValueError as e:
-        console.log(f"Error: {e}")
-        return
-
     # Generate a random value or get value from user
     if random_type:
         # Check if length is specified for key128 or key256
@@ -61,6 +50,6 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
             # Optionally, list secrets after update to confirm the change
             phase_list_secrets(show=False, phase_app=phase_app, env_name=env_name, path=destination_path or source_path)
         else:
-            print(f"Error: Failed to update secret. {response}")
+            print(f"Error: 🗿 Failed to update secret. {response}")
     except ValueError as e:
         console.log(f"⚠️  Error occurred while updating the secret: {e}")

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -158,7 +158,8 @@ def main ():
         )
         secrets_update_parser.add_argument(
             'key', 
-            type=str, 
+            type=str,
+            nargs='?',
             help='The key associated with the secret to update. If the new value is not provided as an argument, it will be read from stdin.'
         )
         secrets_update_parser.add_argument('--env', type=str, help=env_help)

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.17.3"
+__version__ = "1.17.4"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/network.py
+++ b/phase_cli/utils/network.py
@@ -28,7 +28,7 @@ def handle_request_errors(response: requests.Response) -> None:
         return
     
     if response.status_code != 200:
-        error_message = f"🗿 Request failed with status code {response.status_code}"
+        error_message = f"🗿 Request failed with status code {response.status_code} {response.text}"
         if PHASE_DEBUG:
             error_message += f": {response.text}"
         raise Exception(error_message)


### PR DESCRIPTION
This PR make the following changes and improvements:
- Replace blank spaces with underscores of the keys passed to `phase secrets update` and `phase secrets create`. fixed: https://github.com/phasehq/cli/issues/131
- Removed client side checks via phase.get to see weather a secret already exists in  `phase secrets update` and `phase secrets create`
- Print the actual error returned by the Phase API even if `PHASE_DEBUG` is `False`
- Improved of parsing the error messages from the Phase API