### PR TITLE
fix: macos builds

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   pytest:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.11]

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -93,10 +93,21 @@ jobs:
           path: "*.rpm"
         if: matrix.os == 'ubuntu-20.04'
 
-      # Upload binary
-      - uses: actions/upload-artifact@v2
+      - name: Set artifact name
+        run: |
+          if [[ "${{ matrix.os }}" == "macos-14" ]]; then
+            echo "ARTIFACT_NAME=${{ runner.os }}-arm64-binary" >> $GITHUB_ENV
+          elif [[ "${{ matrix.os }}" == "macos-13" ]]; then
+            echo "ARTIFACT_NAME=${{ runner.os }}-amd64-binary" >> $GITHUB_ENV
+          else
+            echo "ARTIFACT_NAME=${{ runner.os }}-binary" >> $GITHUB_ENV
+          fi
+        shell: bash
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
         with:
-          name: ${{ runner.os }}-${{ (matrix.os == 'macos-14' && 'arm64') || (matrix.os == 'macos-13' && 'amd64') }}-binary
+          name: ${{ env.ARTIFACT_NAME }}
           path: dist/phase*
 
   build_arm:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -121,7 +121,7 @@ jobs:
 
   build_apk:
     name: Build CLI (alpine-latest, 3.11)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [pytest]
     container:
       image: python:3.11-alpine
@@ -161,7 +161,7 @@ jobs:
     name: Build & Release - Docker
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [build, build_apk]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -192,7 +192,7 @@ jobs:
   Pull_and_test_docker_image:
     name: Test - CLI - Docker
     needs: Build_and_push_docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Download phase-version artifact
         uses: actions/download-artifact@v2
@@ -216,7 +216,7 @@ jobs:
   attach-assets:
     name: Package assets
     needs: [build, build_apk, build_arm]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Download all the artifacts from the build jobs

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -96,7 +96,7 @@ jobs:
       # Upload binary
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ runner.os }}-binary
+          name: ${{ runner.os }}-${{ (matrix.os == 'macos-14' && 'arm64') || (matrix.os == 'macos-13' && 'amd64') }}-binary
           path: dist/phase*
 
   build_arm:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -267,11 +267,17 @@ jobs:
           mv "$ZIPNAME" phase_cli_release_$VERSION/
           sha256sum phase_cli_release_$VERSION/"$ZIPNAME" > phase_cli_release_$VERSION/phase_cli_windows_amd64_$VERSION.sha256
 
-          # For MacOS
+          # For MacOS Intel build
           ZIPNAME="phase_cli_macos_amd64_$VERSION.zip"
-          zip -r "$ZIPNAME" macOS-binary/phase/ macOS-binary/phase/_internal
+          zip -r "$ZIPNAME" macOS-amd64-binary/phase/ macOS-binary/phase/_internal
           mv "$ZIPNAME" phase_cli_release_$VERSION/
           sha256sum phase_cli_release_$VERSION/"$ZIPNAME" > phase_cli_release_$VERSION/phase_cli_macos_amd64_$VERSION.sha256
+
+          # For MacOS Apple silicon build 
+          ZIPNAME="phase_cli_macos_arm64_$VERSION.zip"
+          zip -r "$ZIPNAME" macOS-arm64-binary/phase/ macOS-binary/phase/_internal
+          mv "$ZIPNAME" phase_cli_release_$VERSION/
+          sha256sum phase_cli_release_$VERSION/"$ZIPNAME" > phase_cli_release_$VERSION/phase_cli_macos_arm64_$VERSION.sha256
 
           # For Alpine build
           ZIPNAME="phase_cli_alpine_linux_amd64_$VERSION.zip"

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,7 +34,7 @@ jobs:
     needs: [pytest]
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-13]
         python-version: [3.11]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,7 +34,7 @@ jobs:
     needs: [pytest]
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-13]
+        os: [ubuntu-20.04, windows-2022, macos-13, macos-14]
         python-version: [3.11]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,7 +34,7 @@ jobs:
     needs: [pytest]
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-13]
+        os: [ubuntu-20.04, windows-2022, macos-13]
         python-version: [3.11]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -34,6 +34,11 @@ jobs:
     needs: [pytest]
     strategy:
       matrix:
+        # ubuntu-20.04 - context: https://github.com/phasehq/cli/issues/94
+        # macos-13 darwin-amd64 builds (intel)
+        # macos-14 darwin-arm64 builds (apple silicon)
+        # context: https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+
         os: [ubuntu-20.04, windows-2022, macos-13, macos-14]
         python-version: [3.11]
     steps:


### PR DESCRIPTION
This PR makes the following changes:
- Make sure macos-amd64 binary is being built on a intel based macos instance. 
- Add a macos-am64 build on macos-14 GitHub action image: https://github.com/actions/runner-images?tab=readme-ov-file#available-images
- Parse the build and process the amd64 and arm64 packages as .zips in Process assets