### PR TITLE
Improved phase run and added tests

### DIFF
--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -55,7 +55,7 @@ def phase_run_inject(command, env_name=None, phase_app=None, tags=None, path: st
                 # Normalize and filter secrets by tags if tags are provided
                 if tags:
                     user_tags = [normalize_tag(tag) for tag in tags.split(',')]
-                    filtered_secrets_dict = {key: value for key, value in resolved_secrets_dict.items() if any(tag_matches(all_secrets[key].get("tags", []), user_tag) for user_tag in user_tags)}
+                    filtered_secrets_dict = {key: value for key, value in resolved_secrets_dict.items() if any(secret['key'] == key and any(tag_matches(secret.get("tags", []), user_tag) for user_tag in user_tags) for secret in all_secrets)}
                 else:
                     filtered_secrets_dict = resolved_secrets_dict
 

--- a/tests/phase_run.py
+++ b/tests/phase_run.py
@@ -6,7 +6,6 @@ import subprocess
 import os
 import sys
 
-# Import the function you are testing
 from phase_cli.cmd.run import phase_run_inject
 
 class TestPhaseRunInject(unittest.TestCase):

--- a/tests/phase_run.py
+++ b/tests/phase_run.py
@@ -1,0 +1,112 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from phase_cli.utils.phase_io import Phase
+from phase_cli.utils.secret_referencing import resolve_all_secrets
+import subprocess
+import os
+import sys
+
+# Import the function you are testing
+from phase_cli.cmd.run import phase_run_inject
+
+class TestPhaseRunInject(unittest.TestCase):
+
+    @patch('phase_cli.cmd.run.subprocess.run')
+    @patch('phase_cli.cmd.run.Console')
+    @patch('phase_cli.cmd.run.Progress')
+    @patch('phase_cli.cmd.run.resolve_all_secrets')
+    @patch('phase_cli.cmd.run.Phase')
+    def test_phase_run_inject_success(self, MockPhase, mock_resolve_all_secrets, MockProgress, MockConsole, mock_subprocess_run):
+        # Arrange phase: set up mock objects and their return values
+        mock_phase_instance = MockPhase.return_value
+        mock_console_instance = MockConsole.return_value
+        mock_progress_instance = MockProgress.return_value.__enter__.return_value
+
+        # Mock the return value of the get method to simulate fetching secrets
+        mock_phase_instance.get.return_value = [
+            {'key': 'SECRET_KEY', 'value': 'secret_value', 'environment': 'dev', 'path': '/', 'application': 'app'},
+            {'key': 'OTHER_SECRET', 'value': 'other_value', 'environment': 'dev', 'path': '/', 'application': 'app'}
+        ]
+
+        # Mock the resolve_all_secrets function to return the secret value as is
+        mock_resolve_all_secrets.side_effect = lambda value, all_secrets, phase, app, env: value
+
+        command = 'echo "Hello World"'
+        env_name = 'dev'
+        phase_app = 'app'
+
+        # Act phase: execute the function under test with a clean environment
+        with patch.dict('os.environ', {}, clear=True):
+            phase_run_inject(command, env_name, phase_app)
+
+        # Assert phase: verify the behavior of the function
+        mock_phase_instance.get.assert_called_once_with(env_name=env_name, app_name=phase_app, tag=None, path='/')
+        mock_resolve_all_secrets.assert_called()
+        mock_subprocess_run.assert_called_once_with(command, shell=True, env=unittest.mock.ANY)
+        new_env = mock_subprocess_run.call_args[1]['env']
+        self.assertIn('SECRET_KEY', new_env)
+        self.assertIn('OTHER_SECRET', new_env)
+        self.assertEqual(new_env['SECRET_KEY'], 'secret_value')
+        self.assertEqual(new_env['OTHER_SECRET'], 'other_value')
+        
+    @patch('phase_cli.cmd.run.subprocess.run')
+    @patch('phase_cli.cmd.run.Console')
+    @patch('phase_cli.cmd.run.Progress')
+    @patch('phase_cli.cmd.run.resolve_all_secrets')
+    @patch('phase_cli.cmd.run.Phase')
+    def test_phase_run_inject_with_different_env(self, MockPhase, mock_resolve_all_secrets, MockProgress, MockConsole, mock_subprocess_run):
+        # Arrange phase: set up mock objects and their return values
+        mock_phase_instance = MockPhase.return_value
+        mock_console_instance = MockConsole.return_value
+        mock_progress_instance = MockProgress.return_value.__enter__.return_value
+
+        # Mock the return value of the get method to simulate fetching secrets from a different environment
+        mock_phase_instance.get.return_value = [
+            {'key': 'SECRET_KEY', 'value': 'secret_value_prod', 'environment': 'prod', 'path': '/', 'application': 'app'},
+            {'key': 'OTHER_SECRET', 'value': 'other_value_prod', 'environment': 'prod', 'path': '/', 'application': 'app'}
+        ]
+
+        # Mock the resolve_all_secrets function to return the secret value as is
+        mock_resolve_all_secrets.side_effect = lambda value, all_secrets, phase, app, env: value
+
+        command = 'echo "Hello World"'
+        env_name = 'prod'
+        phase_app = 'app'
+
+        # Act phase: execute the function under test with a clean environment
+        with patch.dict('os.environ', {}, clear=True):
+            phase_run_inject(command, env_name, phase_app)
+
+        # Assert phase: verify the behavior of the function
+        mock_phase_instance.get.assert_called_once_with(env_name=env_name, app_name=phase_app, tag=None, path='/')
+        mock_resolve_all_secrets.assert_called()
+        mock_subprocess_run.assert_called_once_with(command, shell=True, env=unittest.mock.ANY)
+        new_env = mock_subprocess_run.call_args[1]['env']
+        self.assertIn('SECRET_KEY', new_env)
+        self.assertIn('OTHER_SECRET', new_env)
+        self.assertEqual(new_env['SECRET_KEY'], 'secret_value_prod')
+        self.assertEqual(new_env['OTHER_SECRET'], 'other_value_prod')
+
+    @patch('phase_cli.cmd.run.Console')
+    @patch('phase_cli.cmd.run.Progress')
+    @patch('phase_cli.cmd.run.Phase')
+    def test_phase_run_inject_error_handling(self, MockPhase, MockProgress, MockConsole):
+        # Arrange phase: set up mock objects and their return values
+        mock_phase_instance = MockPhase.return_value
+        mock_console_instance = MockConsole.return_value
+        mock_progress_instance = MockProgress.return_value.__enter__.return_value
+
+        # Mock the get method to raise a ValueError to simulate an error during secret fetching
+        mock_phase_instance.get.side_effect = ValueError("Some error occurred")
+
+        command = 'echo "Hello World"'
+        env_name = 'dev'
+        phase_app = 'app'
+
+        # Act and Assert phase: execute the function under test and expect a SystemExit exception
+        with self.assertRaises(SystemExit):
+            phase_run_inject(command, env_name, phase_app)
+
+        # Verify that the error message was logged
+        mock_console_instance.log.assert_called_with("Error: Some error occurred")
+        mock_phase_instance.get.assert_called_once_with(env_name=env_name, app_name=phase_app, tag=None, path='/')

--- a/tests/secret_referencing.py
+++ b/tests/secret_referencing.py
@@ -1,0 +1,117 @@
+import pytest
+from unittest.mock import Mock, patch
+from phase_cli.utils.secret_referencing import resolve_secret_reference, resolve_all_secrets, EnvironmentNotFoundException
+from phase_cli.utils.const import SECRET_REF_REGEX
+
+# Mock data for secrets
+secrets_dict = {
+    "current": {
+        "/": {
+            "KEY": "value1"
+        },
+        "/backend/payments": {
+            "STRIPE_KEY": "stripe_value"
+        }
+    },
+    "staging": {
+        "/": {
+            "DEBUG": "staging_debug_value"
+        }
+    },
+    "prod": {
+        "/frontend": {
+            "SECRET_KEY": "prod_secret_value"
+        }
+    }
+}
+
+# Mock Phase class
+class MockPhase:
+    def get(self, env_name, app_name, keys, path):
+        if env_name == "prod" and path == "/frontend":
+            return [{"key": "SECRET_KEY", "value": "prod_secret_value"}]
+        raise EnvironmentNotFoundException(env_name=env_name)
+
+@pytest.fixture
+def phase():
+    return MockPhase()
+
+@pytest.fixture
+def current_env_name():
+    return "current"
+
+@pytest.fixture
+def current_application_name():
+    return "test_app"
+
+def test_resolve_local_reference_root(phase, current_application_name, current_env_name):
+    ref = "KEY"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "value1"
+
+def test_resolve_local_reference_path(phase, current_application_name, current_env_name):
+    ref = "/backend/payments/STRIPE_KEY"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "stripe_value"
+
+def test_resolve_cross_environment_root(phase, current_application_name, current_env_name):
+    ref = "staging.DEBUG"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "staging_debug_value"
+
+def test_resolve_cross_environment_path(phase, current_application_name, current_env_name):
+    ref = "prod./frontend/SECRET_KEY"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "prod_secret_value"
+
+def test_resolve_all_secrets(phase, current_application_name, current_env_name):
+    value = "Use this key: ${KEY}, and this staging key: ${staging.DEBUG}, and this path key: ${/backend/payments/STRIPE_KEY}"
+    all_secrets = [
+        {"environment": "current", "path": "/", "key": "KEY", "value": "value1"},
+        {"environment": "staging", "path": "/", "key": "DEBUG", "value": "staging_debug_value"},
+        {"environment": "current", "path": "/backend/payments", "key": "STRIPE_KEY", "value": "stripe_value"}
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    expected_value = "Use this key: value1, and this staging key: staging_debug_value, and this path key: stripe_value"
+    assert resolved_value == expected_value
+
+# Edge Case: Missing key in the current environment
+def test_resolve_missing_local_key(phase, current_application_name, current_env_name):
+    ref = "MISSING_KEY"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "${MISSING_KEY}"
+
+# Edge Case: Missing key in a cross environment reference
+def test_resolve_missing_cross_env_key(phase, current_application_name, current_env_name):
+    ref = "prod.MISSING_KEY"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "${prod.MISSING_KEY}"
+
+# Edge Case: Missing path in a cross environment reference
+def test_resolve_missing_cross_env_path(phase, current_application_name, current_env_name):
+    ref = "prod./missing_path/SECRET_KEY"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "${prod./missing_path/SECRET_KEY}"
+
+# Complex Case: Mixed references with missing values
+def test_resolve_mixed_references_with_missing(phase, current_application_name, current_env_name):
+    value = "Local: ${KEY}, Missing Local: ${MISSING_KEY}, Cross: ${staging.DEBUG}, Missing Cross: ${prod.MISSING_KEY}"
+    all_secrets = [
+        {"environment": "current", "path": "/", "key": "KEY", "value": "value1"},
+        {"environment": "staging", "path": "/", "key": "DEBUG", "value": "staging_debug_value"}
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    expected_value = "Local: value1, Missing Local: ${MISSING_KEY}, Cross: staging_debug_value, Missing Cross: ${prod.MISSING_KEY}"
+    assert resolved_value == expected_value
+
+# Edge Case: Local reference with missing path
+def test_resolve_local_reference_missing_path(phase, current_application_name, current_env_name):
+    ref = "/missing_path/KEY"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "${/missing_path/KEY}"
+
+# Edge Case: Invalid reference format
+def test_resolve_invalid_reference_format(phase, current_application_name, current_env_name):
+    ref = "invalid_format"
+    resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
+    assert resolved_value == "${invalid_format}"


### PR DESCRIPTION
- removed redundant tag filtering logic in phase run, handle tag in phase.get() instead (to be consistent with phase secrets export)
- added unit test for phase run

