### PR TITLE
Feat: secret override support

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.17.5
+pkgver=1.18.0
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -52,7 +52,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
 
     # If override is enabled, get the overridden value from the user
     if override:
-        override_value = getpass.getpass("✨ Please enter the 🔏 overridden value (hidden): ")
+        override_value = getpass.getpass("✨ Please enter the 🔏 override value (hidden): ")
     else:
         override_value = None
 

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -5,9 +5,9 @@ from phase_cli.cmd.secrets.list import phase_list_secrets
 from phase_cli.utils.crypto import generate_random_secret
 from rich.console import Console
 
-def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=None, random_length=None, path='/'):
+def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=None, random_length=None, path='/', override=False):
     """
-    Creates a new secret, encrypts it, and syncs it with the Phase, with support for specifying a path.
+    Creates a new secret, encrypts it, and syncs it with the Phase, with support for specifying a path and overrides.
 
     Args:
         key (str, optional): The key of the new secret. Defaults to None.
@@ -16,6 +16,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         random_type (str, optional): The type of random secret to generate (e.g., 'hex', 'alphanumeric'). Defaults to None.
         random_length (int, optional): The length of the random secret. Defaults to 32.
         path (str, optional): The path under which to store the secrets. Defaults to the root path '/'.
+        override (bool, optional): Whether to create an overridden secret. Defaults to False.
     """
 
     # Initialize the Phase class
@@ -29,8 +30,10 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         # Replace spaces in the key with underscores
         key = key.replace(' ', '_').upper()
 
-    # Generate a random value or get value from user
-    if random_type:
+    # Generate a random value or get value from user, unless override is enabled
+    if override:
+        value = ""
+    elif random_type:
         # Check if length is specified for key128 or key256
         if random_type in ['key128', 'key256'] and random_length != 32:
             print("⚠️\u200A Warning: The length argument is ignored for 'key128' and 'key256'. Using default lengths.")
@@ -47,9 +50,15 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         else:
             value = sys.stdin.read().strip()
 
+    # If override is enabled, get the overridden value from the user
+    if override:
+        override_value = getpass.getpass("✨ Please enter the 🔏 overridden value (hidden): ")
+    else:
+        override_value = None
+
     try:
         # Encrypt and POST secret to the backend using phase create
-        response = phase.create(key_value_pairs=[(key, value)], env_name=env_name, app_name=phase_app, path=path)
+        response = phase.create(key_value_pairs=[(key, value)], env_name=env_name, app_name=phase_app, path=path, override_value=override_value)
 
         # Check the response status code
         if response.status_code == 200:

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -47,11 +47,11 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
             return
     elif not override:
         if sys.stdin.isatty():
-            new_value = getpass.getpass(f"Please enter the new value for {key} (hidden): ")
+            new_value = getpass.getpass(f"✨ Please enter the new value for {key} (hidden): ")
         else:
             new_value = sys.stdin.read().strip()
     else:
-        new_value = getpass.getpass(f"✨ Please enter the new overridden value for {key} (hidden): ")
+        new_value = getpass.getpass(f"✨ Please enter the new 🔏 override value for {key} (hidden): ")
 
     # Update the secret with optional source and destination path support
     try:

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -193,6 +193,16 @@ def main ():
                                             type=str, 
                                             help='The new path for the secret, if changing its location. If not provided, the secret\'s path is not updated. Example usage: --updated-path "/folder/subfolder"')
 
+        # Adding the --override argument for personal secret override
+        secrets_update_parser.add_argument('--override', 
+                                            action='store_true', 
+                                            help='🔏 Update the personal override value.')
+
+        # Adding the --toggle-override argument to toggle the override state
+        secrets_update_parser.add_argument('--toggle-override', 
+                                            action='store_true', 
+                                            help='🔄 Toggle the override state between active and inactive.')
+
         # Secrets delete command
         secrets_delete_parser = secrets_subparsers.add_parser('delete', help='🗑️\u200A Delete a secret')
         secrets_delete_parser.add_argument('keys', nargs='*', help='Keys to be deleted')
@@ -292,7 +302,7 @@ def main ():
             elif args.secrets_command == 'export':
                 phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, path=args.path, tags=args.tags, format=args.format)
             elif args.secrets_command == 'update':
-                phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, source_path=args.path, destination_path=args.updated_path, random_type=args.random, random_length=args.length)
+                phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, source_path=args.path, destination_path=args.updated_path, random_type=args.random, random_length=args.length, override=args.override, toggle_override=args.toggle_override)
             else:
                 print("Unknown secrets sub-command: " + args.secrets_command)
                 parser.print_help()

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -137,6 +137,7 @@ def main ():
         secrets_create_parser.add_argument('--env', type=str, help=env_help)
         secrets_create_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
         secrets_create_parser.add_argument('--path', type=str, default='/', help="The path in which you want to create a secret. You can create a directory by simply specifying a path like so: --path /folder/SECRET. Default is '/'")
+        
         # Adding the --random argument
         random_types = ['hex', 'alphanumeric', 'base64', 'base64url', 'key128', 'key256']
         secrets_create_parser.add_argument('--random', 
@@ -149,6 +150,11 @@ def main ():
                                         type=int, 
                                         default=32, 
                                         help='🔢 Specify the length of the random value. Applicable for types other than key128 and key256. Default is 32. Example usage: --length 16')
+
+        # Adding the --override argument
+        secrets_create_parser.add_argument('--override', 
+                                        action='store_true', 
+                                        help='🔏 Specify if the secret is a personal override. Default is False.')
 
         # Secrets update command
         secrets_update_parser = secrets_subparsers.add_parser(
@@ -278,7 +284,7 @@ def main ():
             elif args.secrets_command == 'get':
                 phase_secrets_get(args.key, env_name=args.env, phase_app=args.app, path=args.path, tags=args.tags)  
             elif args.secrets_command == 'create':
-                phase_secrets_create(args.key, env_name=args.env, phase_app=args.app, path=args.path, random_type=args.random, random_length=args.length)
+                phase_secrets_create(args.key, env_name=args.env, phase_app=args.app, path=args.path, random_type=args.random, random_length=args.length, override=args.override)
             elif args.secrets_command == 'delete':
                 phase_secrets_delete(args.keys, env_name=args.env, path=args.path, phase_app=args.app)  
             elif args.secrets_command == 'import':

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.17.5"
+__version__ = "1.18.0"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/phase_io.py
+++ b/phase_cli/utils/phase_io.py
@@ -268,7 +268,6 @@ class Phase:
         # Fetch secrets from the specified source path
         secrets_response = fetch_phase_secrets(self._token_type, self._app_secret.app_token, env_id, self._api_host, path=source_path)
         secrets_data = secrets_response.json()
-        print("secrets_data", secrets_data)
 
         wrapped_seed = environment_key.get("wrapped_seed")
         decrypted_seed = self.decrypt(wrapped_seed)
@@ -309,7 +308,6 @@ class Phase:
                     "isActive": toggle_override  # Activate override if it's being toggled for the first time
                 }
 
-        print("secret_update_payload", secret_update_payload)
         response = update_phase_secrets(self._token_type, self._app_secret.app_token, env_id, [secret_update_payload], self._api_host)
 
         if response.status_code == 200:

--- a/phase_cli/utils/phase_io.py
+++ b/phase_cli/utils/phase_io.py
@@ -289,7 +289,7 @@ class Phase:
             "id": matching_secret["id"],
             "key": encrypted_key,
             "keyDigest": key_digest,
-            "value": encrypted_value,
+            "value": encrypted_value if not override else matching_secret["value"],
             "tags": matching_secret.get("tags", []), # TODO: Implement tags and comments updates
             "comment": matching_secret.get("comment", ""),
             "path": destination_path if destination_path is not None else matching_secret["path"]
@@ -314,7 +314,6 @@ class Phase:
             return "Success"
         else:
             return f"Error: Failed to update secret. HTTP Status Code: {response.status_code}"
-
 
 
     def delete(self, env_name: str, keys_to_delete: List[str], app_name: str = None, path: str = None) -> List[str]:


### PR DESCRIPTION
**PR Description:**

This PR adds personal secret override support to the CLI. Previously to toggle or set a personal value to a secret a user would have to go to the Phase Console, this change makes it more convenient as well as makes is easy to script automations using the CLI.

### Changes:
1. **Override Update:**
   - Modified the `update` method to ensure that the personal override value is updated when the `--override` flag is used.
   - Ensured that the shared secret value is updated only when the `--override` flag is not set.

2. **Toggle Override:**
   - Implemented the `--toggle-override` functionality to toggle the `isActive` state for personal overrides during updates.
   - Added logic to handle the toggle operation correctly.

3. **Command Updates:**
   - Updated the `create` and `update` commands to support the `--override` flag.
   - Updated the `update` command to support the `--toggle-override` flag.
   - Clarified that the `--toggle-override` flag does not apply to the `create` command.

### Commands:
- `create`:
  - `--override` 🔏 Update the personal override value.

- `update`:
  - `--override` 🔏 Update the personal override value.
  - `--toggle-override` 🔄 Toggle the override state between active and inactive.

### Testing:
- Verified that updating a secret with the `--override` flag correctly updates the personal override value.
- Ensured that toggling the override state using the `--toggle-override` flag works as expected.
- Confirmed that the `--toggle-override` flag does not apply to the `create` command.
