### PR TITLE
feat: don't set the secret key to upper case by default

### DIFF
--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -28,7 +28,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
         key = input("🗝️\u200A Please enter the key: ")
 
     # Replace spaces in the key with underscores
-    key = key.replace(' ', '_').upper()
+    key = key.replace(' ', '_')
 
     # Generate a random value or get value from user, unless override is enabled
     if override:

--- a/phase_cli/cmd/secrets/delete.py
+++ b/phase_cli/cmd/secrets/delete.py
@@ -22,9 +22,6 @@ def phase_secrets_delete(keys_to_delete: List[str] = None, env_name: str = None,
         keys_to_delete_input = input("Please enter the keys to delete (separate multiple keys with a space): ")
         keys_to_delete = keys_to_delete_input.split()
 
-    # Convert each key to uppercase
-    keys_to_delete = [key.upper() for key in keys_to_delete]
-
     try:
         # Delete keys within the specified path and get the list of keys not found
         keys_not_found = phase.delete(env_name=env_name, keys_to_delete=keys_to_delete, app_name=phase_app, path=path)

--- a/phase_cli/cmd/secrets/get.py
+++ b/phase_cli/cmd/secrets/get.py
@@ -17,7 +17,7 @@ def phase_secrets_get(key, env_name=None, phase_app=None, tags=None, path='/'):
     console = Console()
     
     try:
-        key = key.upper()
+        
         secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app, tag=tags, path=path)
         
         # Find the specific secret for the given key within the provided path

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -29,7 +29,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
         key = input("🗝️\u200A Please enter the key: ")
 
     # Replace spaces in the key with underscores
-    key = key.replace(' ', '_').upper()
+    key = key.replace(' ', '_')
 
     # Check if toggle_override is provided, if so, do not prompt for a new value
     if toggle_override:


### PR DESCRIPTION
This PR make several changes to the Phase CLI's secrets CRUD sub commands allowing for users to dictate naming convention of the keys of their secret.

Change: The CLI will no longer by default create, fetch, update and search (when deleting) in upper case.

The only exception here is the import sub-command, when its importing keys from a `.env` file it will automatically apply upper case to each key imported from the file.