### PR TITLE
Feat: add --app-id flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,24 +46,6 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
 
-      # # Download the version file
-      # - uses: actions/download-artifact@v4
-      #   with:
-      #     name: phase-version
-      
-      # # DEBUG
-      # - name: List files after downloading artifact
-      #   shell: bash
-      #   run: ls -al
-
-      # # Set the version environment variable
-      # - name: Set VERSION
-      #   shell: bash
-      #   run: |
-      #     PHASE_CLI_VERSION=$(cat PHASE_CLI_VERSION.txt)
-      #     echo "PHASE_CLI_VERSION is: $PHASE_CLI_VERSION"
-      #     echo "PHASE_CLI_VERSION=$PHASE_CLI_VERSION" >> $GITHUB_ENV
-
       # Build DEB and RPM packages for Linux
       - run: |
           sudo apt-get update

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -39,8 +39,3 @@ jobs:
           else
             echo "Versions match: ${{ steps.extract_version.outputs.version }}"
           fi
-
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: phase-version
-      #     path: ./PHASE_CLI_VERSION.txt

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.18.4
+pkgver=1.18.5
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -7,7 +7,7 @@ from phase_cli.utils.secret_referencing import resolve_all_secrets
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
 
-def phase_run_inject(command, env_name=None, phase_app=None, tags=None, path: str = '/'):
+def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, tags=None, path: str = '/'):
     """
     Executes a shell command with environment variables set to the secrets 
     fetched from Phase for the specified environment, resolving references as needed.
@@ -31,7 +31,7 @@ def phase_run_inject(command, env_name=None, phase_app=None, tags=None, path: st
                 task1 = progress.add_task("[bold green]Fetching secrets...", total=None)        
 
                 # Fetch all secrets
-                all_secrets = phase.get(env_name=env_name, app_name=phase_app, tag=tags, path=path)
+                all_secrets = phase.get(env_name=env_name, app_name=phase_app, app_id=phase_app_id, tag=tags, path=path)
                 
                 # Organize all secrets into a dictionary for easier lookup
                 secrets_dict = {}

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -5,7 +5,7 @@ from phase_cli.cmd.secrets.list import phase_list_secrets
 from phase_cli.utils.crypto import generate_random_secret
 from rich.console import Console
 
-def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=None, random_length=None, path='/', override=False):
+def phase_secrets_create(key=None, env_name=None, phase_app=None, phase_app_id=None, random_type=None, random_length=None, path='/', override=False):
     """
     Creates a new secret, encrypts it, and syncs it with the Phase, with support for specifying a path and overrides.
 
@@ -58,7 +58,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, random_type=No
 
     try:
         # Encrypt and POST secret to the backend using phase create
-        response = phase.create(key_value_pairs=[(key, value)], env_name=env_name, app_name=phase_app, path=path, override_value=override_value)
+        response = phase.create(key_value_pairs=[(key, value)], env_name=env_name, app_name=phase_app, app_id=phase_app_id, path=path, override_value=override_value)
 
         # Check the response status code
         if response.status_code == 200:

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -36,7 +36,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, phase_app_id=N
     elif random_type:
         # Check if length is specified for key128 or key256
         if random_type in ['key128', 'key256'] and random_length != 32:
-            print("⚠️\u200A Warning: The length argument is ignored for 'key128' and 'key256'. Using default lengths.")
+            console.log("⚠️\u200A Warning: The length argument is ignored for 'key128' and 'key256'. Using default lengths.")
 
         try:
             value = generate_random_secret(random_type, random_length)
@@ -66,7 +66,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, phase_app_id=N
             phase_list_secrets(show=False, phase_app=phase_app, phase_app_id=phase_app_id, env_name=env_name, path=path)
         else:
             # Print an error message if the response status code indicates an error
-            print(f"Error: Failed to create secret. HTTP Status Code: {response.status_code}")
+            console.log(f"Error: Failed to create secret. HTTP Status Code: {response.status_code}")
 
     except ValueError as e:
         console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -63,7 +63,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, phase_app_id=N
         # Check the response status code
         if response.status_code == 200:
             # Call the phase_list_secrets function to list the secrets
-            phase_list_secrets(show=False, phase_app=phase_app, env_name=env_name, path=path)
+            phase_list_secrets(show=False, phase_app=phase_app, phase_app_id=phase_app_id, env_name=env_name, path=path)
         else:
             # Print an error message if the response status code indicates an error
             print(f"Error: Failed to create secret. HTTP Status Code: {response.status_code}")

--- a/phase_cli/cmd/secrets/delete.py
+++ b/phase_cli/cmd/secrets/delete.py
@@ -3,7 +3,7 @@ from phase_cli.cmd.secrets.list import phase_list_secrets
 from rich.console import Console
 from typing import List
 
-def phase_secrets_delete(keys_to_delete: List[str] = None, env_name: str = None, phase_app: str = None, path: str = None):
+def phase_secrets_delete(keys_to_delete: List[str] = None, env_name: str = None, phase_app: str = None, phase_app_id: str = None, path: str = None):
     """
     Deletes encrypted secrets based on key values, with optional path support.
 
@@ -27,7 +27,7 @@ def phase_secrets_delete(keys_to_delete: List[str] = None, env_name: str = None,
 
     try:
         # Delete keys within the specified path and get the list of keys not found
-        keys_not_found = phase.delete(env_name=env_name, keys_to_delete=keys_to_delete, app_name=phase_app, path=path)
+        keys_not_found = phase.delete(env_name=env_name, keys_to_delete=keys_to_delete, app_name=phase_app, app_id=phase_app_id, path=path)
 
         if keys_not_found:
             console.log(f"⚠️  Warning: The following keys were not found: {', '.join(keys_not_found)}")

--- a/phase_cli/cmd/secrets/delete.py
+++ b/phase_cli/cmd/secrets/delete.py
@@ -35,7 +35,7 @@ def phase_secrets_delete(keys_to_delete: List[str] = None, env_name: str = None,
             console.log("✅ Successfully deleted the secrets.")
 
         # Optionally, list remaining secrets to confirm deletion
-        phase_list_secrets(show=False, env_name=env_name, phase_app=phase_app, path=path)
+        phase_list_secrets(show=False, env_name=env_name, phase_app=phase_app, phase_app_id=phase_app_id, path=path)
     
     except ValueError as e:
         console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn
 
 
-def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None, format='dotenv', path: str = ''):
+def phase_secrets_env_export(env_name=None, phase_app=None, phase_app_id=None, keys=None, tags=None, format='dotenv', path: str = ''):
     """
     Exports secrets from the specified environment with support for multiple export formats. 
     This function fetches secrets from Phase, resolves any cross-environment or local secret references, and then outputs them in the chosen format.
@@ -51,7 +51,7 @@ def phase_secrets_env_export(env_name=None, phase_app=None, keys=None, tags=None
 
     try:
         # Fetch all secrets
-        all_secrets = phase.get(env_name=env_name, app_name=phase_app, tag=tags, path=path)
+        all_secrets = phase.get(env_name=env_name, app_name=phase_app, app_id=phase_app_id, tag=tags, path=path)
 
         # Organize all secrets into a dictionary for easier lookup.
         secrets_dict = {}

--- a/phase_cli/cmd/secrets/get.py
+++ b/phase_cli/cmd/secrets/get.py
@@ -2,7 +2,7 @@ from phase_cli.utils.phase_io import Phase
 from rich.console import Console
 import json
 
-def phase_secrets_get(key, env_name=None, phase_app=None, tags=None, path='/'):
+def phase_secrets_get(key, env_name=None, phase_app=None, phase_app_id=None, tags=None, path='/'):
     """
     Fetch and print a single secret based on a given key as beautified JSON with syntax highlighting.
 
@@ -18,7 +18,7 @@ def phase_secrets_get(key, env_name=None, phase_app=None, tags=None, path='/'):
     
     try:
         key = key.upper()
-        secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app, tag=tags, path=path)
+        secrets_data = phase.get(env_name=env_name, keys=[key], app_name=phase_app, app_id=phase_app_id, tag=tags, path=path)
         
         # Find the specific secret for the given key within the provided path
         secret_data = next((secret for secret in secrets_data if secret["key"] == key), None)

--- a/phase_cli/cmd/secrets/import_env.py
+++ b/phase_cli/cmd/secrets/import_env.py
@@ -32,7 +32,7 @@ def phase_secrets_env_import(env_file, env_name=None, phase_app=None, phase_app_
                 secrets.append((key.strip().upper(), sanitize_value(value.strip())))
     
     except FileNotFoundError:
-        print(f"Error: The file {env_file} was not found.")
+        console.log(f"Error: The file {env_file} was not found.")
         sys.exit(1)
     
     try:
@@ -41,14 +41,14 @@ def phase_secrets_env_import(env_file, env_name=None, phase_app=None, phase_app_
         
         # Check the response status code
         if response.status_code == 200:
-            print(f"Successfully imported and encrypted {len(secrets)} secrets.")
+            console.log(f"✅ Successfully imported and encrypted {len(secrets)} secrets.")
             if env_name == None:
-                print("To view them please run: phase secrets list")
+                console.log("To view them please run: phase secrets list")
             else:
-                print(f"To view them please run: phase secrets list --env {env_name}")
+                console.log(f"To view them please run: phase secrets list --env {env_name}")
         else:
             # Print an error message if the response status code indicates an error
-            print(f"Error: Failed to import secrets. HTTP Status Code: {response.status_code}")
+            console.log(f"Error: Failed to import secrets. HTTP Status Code: {response.status_code}")
 
     except ValueError as e:
         console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/import_env.py
+++ b/phase_cli/cmd/secrets/import_env.py
@@ -3,7 +3,7 @@ from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.misc import get_default_user_id, sanitize_value
 from rich.console import Console
 
-def phase_secrets_env_import(env_file, env_name=None, phase_app=None, path: str = '/'):
+def phase_secrets_env_import(env_file, env_name=None, phase_app=None, phase_app_id=None, path: str = '/'):
     """
     Imports existing environment variables and secrets from a user's .env file.
 
@@ -37,7 +37,7 @@ def phase_secrets_env_import(env_file, env_name=None, phase_app=None, path: str 
     
     try:
         # Encrypt and send secrets to the backend using the `create` method
-        response = phase.create(key_value_pairs=secrets, env_name=env_name, app_name=phase_app, path=path)
+        response = phase.create(key_value_pairs=secrets, env_name=env_name, app_name=phase_app, app_id=phase_app_id, path=path)
         
         # Check the response status code
         if response.status_code == 200:

--- a/phase_cli/cmd/secrets/list.py
+++ b/phase_cli/cmd/secrets/list.py
@@ -2,7 +2,7 @@ from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.misc import render_tree_with_tables
 from rich.console import Console
 
-def phase_list_secrets(show=False, env_name=None, phase_app=None, tags=None, path=''):
+def phase_list_secrets(show=False, env_name=None, phase_app=None, phase_app_id=None, tags=None, path=''):
     """
     Lists the secrets fetched from Phase for the specified environment, optionally filtered by tags and path.
 
@@ -21,7 +21,7 @@ def phase_list_secrets(show=False, env_name=None, phase_app=None, tags=None, pat
     console = Console()
 
     try:
-        secrets_data = phase.get(env_name=env_name, app_name=phase_app, tag=tags, path=path)
+        secrets_data = phase.get(env_name=env_name, app_name=phase_app, app_id=phase_app_id, tag=tags, path=path)
         
         # Check that secrets_data is a list of dictionaries
         if not isinstance(secrets_data, list):

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -70,7 +70,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None, phase_app_id=None, 
             console.log("✅ Successfully updated the secret.")
             
             # Optionally, list secrets after update to confirm the change
-            phase_list_secrets(show=False, phase_app=phase_app, env_name=env_name, path=destination_path or source_path)
+            phase_list_secrets(show=False, phase_app=phase_app, env_name=env_name, phase_app_id=phase_app_id, path=destination_path or source_path)
         else:
             console.log(f"{response}")
     except ValueError as e:

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -5,7 +5,7 @@ from phase_cli.cmd.secrets.list import phase_list_secrets
 from phase_cli.utils.crypto import generate_random_secret
 from rich.console import Console
 
-def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, random_length=None, source_path='', destination_path=None, override=False, toggle_override=False):
+def phase_secrets_update(key, env_name=None, phase_app=None, phase_app_id=None, random_type=None, random_length=None, source_path='', destination_path=None, override=False, toggle_override=False):
     """
     Updates a secret with a new value or a randomly generated value, with optional source and destination path support.
 
@@ -59,7 +59,8 @@ def phase_secrets_update(key, env_name=None, phase_app=None, random_type=None, r
             env_name=env_name, 
             key=key, 
             value=new_value, 
-            app_name=phase_app, 
+            app_name=phase_app,
+            app_id=phase_app_id,
             source_path=source_path, 
             destination_path=destination_path, 
             override=override, 

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -175,7 +175,8 @@ def main ():
             help='The key associated with the secret to update. If the new value is not provided as an argument, it will be read from stdin.'
         )
         secrets_update_parser.add_argument('--env', type=str, help=env_help)
-        secrets_update_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_update_parser.add_argument('--app', type=str, help=app_help)
+        secrets_update_parser.add_argument('--app-id', type=str, help=app_id_help)
 
         # Handle the --random argument
         random_types = ['hex', 'alphanumeric', 'base64', 'base64url', 'key128', 'key256']

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -70,6 +70,8 @@ class HelpfulParser(argparse.ArgumentParser):
 def main ():
     env_help = "Environment name eg. dev, staging, production"
     tag_help = '🏷️: Comma-separated list of tags to filter the secrets. Tags are case-insensitive and support partial matching. For example, using --tags "prod,config" will include secrets tagged with "Production" or "ConfigData". Underscores in tags are treated as spaces, so "prod_data" matches "prod data".'
+    app_help = 'The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.'
+    app_id_help = 'The ID of your Phase application. Takes precedence over --app if both are provided.'
     console = Console()
 
     try:
@@ -90,7 +92,8 @@ def main ():
         run_parser = subparsers.add_parser('run', help='🚀 Run and inject secrets to your app')
         run_parser.add_argument('command_to_run', nargs=argparse.REMAINDER, help='Command to be run. Ex. phase run yarn dev')
         run_parser.add_argument('--env', type=str, help=env_help)
-        run_parser.add_argument('--app', type=str, help='Name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        run_parser.add_argument('--app', type=str, help=app_help)
+        run_parser.add_argument('--app-id', type=str, help=app_id_help)
         run_parser.add_argument('--path', type=str, default='/', help="Specific path under which to fetch secrets from and inject into your application. Default is '/'")
         run_parser.add_argument('--tags', type=str, help=tag_help)
 
@@ -102,7 +105,8 @@ def main ():
         secrets_list_parser = secrets_subparsers.add_parser('list', help='📇 List all the secrets')
         secrets_list_parser.add_argument('--show', action='store_true', help='Return secrets uncensored')
         secrets_list_parser.add_argument('--env', type=str, help=env_help)
-        secrets_list_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_list_parser.add_argument('--app', type=str, help=app_help)
+        secrets_list_parser.add_argument('--app-id', type=str, help=app_id_help)
         secrets_list_parser.add_argument('--path', type=str, help="The path in which you want to list secrets.")
         secrets_list_parser.add_argument('--tags', type=str, help=tag_help)
         secrets_list_parser.epilog = (
@@ -118,7 +122,8 @@ def main ():
         secrets_get_parser = secrets_subparsers.add_parser('get', help='🔍 Fetch details about a secret in JSON')
         secrets_get_parser.add_argument('key', type=str, help='The key associated with the secret to fetch')
         secrets_get_parser.add_argument('--env', type=str, help=env_help)
-        secrets_get_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_get_parser.add_argument('--app', type=str, help=app_help)
+        secrets_get_parser.add_argument('--app-id', type=str, help=app_id_help)
         secrets_get_parser.add_argument('--tags', type=str, help=tag_help)
         secrets_get_parser.add_argument('--path', type=str, default='/', required=False, help="The path from which to fetch the secret from. Default is '/'")
 
@@ -135,23 +140,24 @@ def main ():
             help='The key for the secret to be created. (Will be converted to uppercase.) If the value is not provided as an argument, it will be read from stdin.'
         )
         secrets_create_parser.add_argument('--env', type=str, help=env_help)
-        secrets_create_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_create_parser.add_argument('--app', type=str, help=app_help)
+        secrets_create_parser.add_argument('--app-id', type=str, help=app_id_help)
         secrets_create_parser.add_argument('--path', type=str, default='/', help="The path in which you want to create a secret. You can create a directory by simply specifying a path like so: --path /folder/SECRET. Default is '/'")
         
-        # Adding the --random argument
+        # Handle the --random argument
         random_types = ['hex', 'alphanumeric', 'base64', 'base64url', 'key128', 'key256']
         secrets_create_parser.add_argument('--random', 
                                         type=str, 
                                         choices=random_types, 
                                         help='🎲 Specify the type of random value to generate. Available types: ' + ', '.join(random_types) + '. Example usage: --random hex')
 
-        # Adding the --length argument
+        # Handle the --length argument
         secrets_create_parser.add_argument('--length', 
                                         type=int, 
                                         default=32, 
                                         help='🔢 Specify the length of the random value. Applicable for types other than key128 and key256. Default is 32. Example usage: --length 16')
 
-        # Adding the --override argument
+        # Handle the --override argument
         secrets_create_parser.add_argument('--override', 
                                         action='store_true', 
                                         help='🔏 Specify if the secret is a personal override. Default is False.')
@@ -171,20 +177,20 @@ def main ():
         secrets_update_parser.add_argument('--env', type=str, help=env_help)
         secrets_update_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
 
-        # Adding the --random argument
+        # Handle the --random argument
         random_types = ['hex', 'alphanumeric', 'base64', 'base64url', 'key128', 'key256']
         secrets_update_parser.add_argument('--random', 
                                             type=str, 
                                             choices=random_types, 
                                             help='🎲 Specify the type of random value to generate. Available types: ' + ', '.join(random_types) + '. Example usage: --random hex')
 
-        # Adding the --length argument
+        # Handle the --length argument
         secrets_update_parser.add_argument('--length', 
                                             type=int, 
                                             default=32, 
                                             help='🔢 Specify the length of the random value. Applicable for types other than key128 and key256. Default is 32. Example usage: --length 16')
 
-        # Adding the --path and --updated-path arguments for path management
+        # Handle the --path and --updated-path arguments for path management
         secrets_update_parser.add_argument('--path', 
                                             type=str, 
                                             default='/', 
@@ -193,12 +199,12 @@ def main ():
                                             type=str, 
                                             help='The new path for the secret, if changing its location. If not provided, the secret\'s path is not updated. Example usage: --updated-path "/folder/subfolder"')
 
-        # Adding the --override argument for personal secret override
+        # Handle the --override argument for personal secret override
         secrets_update_parser.add_argument('--override', 
                                             action='store_true', 
                                             help='🔏 Update the personal override value.')
 
-        # Adding the --toggle-override argument to toggle the override state
+        # Handle the --toggle-override argument to toggle the override state
         secrets_update_parser.add_argument('--toggle-override', 
                                             action='store_true', 
                                             help='🔄 Toggle the override state between active and inactive.')
@@ -207,26 +213,29 @@ def main ():
         secrets_delete_parser = secrets_subparsers.add_parser('delete', help='🗑️\u200A Delete a secret')
         secrets_delete_parser.add_argument('keys', nargs='*', help='Keys to be deleted')
         secrets_delete_parser.add_argument('--env', type=str, help=env_help)
-        secrets_delete_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_delete_parser.add_argument('--app', type=str, help=app_help)
+        secrets_delete_parser.add_argument('--app-id', type=str, help=app_id_help)
 
-        # Adding the --path argument
+        # Handle the --path argument
         secrets_delete_parser.add_argument('--path', 
-                                            type=str, 
-                                            default='/', 
-                                            help='The path within which to delete the secrets. If specified, only deletes secrets within this path. Defaults to the root path \'/\'. Example usage: --path "/myfolder/subfolder"')
+                                        type=str, 
+                                        default='/', 
+                                        help='The path within which to delete the secrets. If specified, only deletes secrets within this path. Defaults to the root path \'/\'. Example usage: --path "/myfolder/subfolder"')
 
         # Secrets import command
         secrets_import_parser = secrets_subparsers.add_parser('import', help='📩 Import secrets from a .env file')
         secrets_import_parser.add_argument('env_file', type=str, help='The .env file to import')
         secrets_import_parser.add_argument('--env', type=str, help=env_help)
-        secrets_import_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_import_parser.add_argument('--app', type=str, help=app_help)
+        secrets_import_parser.add_argument('--app-id', type=str, help=app_id_help)
         secrets_import_parser.add_argument('--path', type=str, default='/', help="The path to which you want to import secret(s). Default is '/'")
 
         # Secrets export command
         secrets_export_parser = secrets_subparsers.add_parser('export', help='🥡 Export secrets in a specific format')
         secrets_export_parser.add_argument('keys', nargs='*', help='List of keys separated by space', default=None)
         secrets_export_parser.add_argument('--env', type=str, help=env_help)
-        secrets_export_parser.add_argument('--app', type=str, help='The name of your Phase application. Optional: If you don\'t have a .phase.json file in your project directory or simply want to override it.')
+        secrets_export_parser.add_argument('--app', type=str, help=app_help)
+        secrets_export_parser.add_argument('--app-id', type=str, help=app_id_help)
         secrets_export_parser.add_argument('--path', type=str, default='/', help="The path from which you want to export secret(s). Default is '/'")
         secrets_export_parser.add_argument('--format', type=str, default='dotenv', choices=['dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 'java_properties'], help='Specifies the export format. Supported formats: dotenv (default), json, csv, yaml, xml, toml, hcl, ini, java_properties.')
         secrets_export_parser.add_argument('--tags', type=str, help=tag_help)
@@ -238,7 +247,7 @@ def main ():
         # Users whoami command
         whoami_parser = users_subparsers.add_parser('whoami', help='🙋 See details of the current user')
 
-        # Users switch command - new addition
+        # Users switch command
         switch_parser = users_subparsers.add_parser('switch', help='🪄\u200A Switch between Phase users, orgs and hosts')
 
         # Users logout command
@@ -267,7 +276,7 @@ def main ():
             phase_init()
         elif args.command == 'run':
             command = ' '.join(args.command_to_run)
-            phase_run_inject(command, env_name=args.env, phase_app=args.app, path=args.path, tags=args.tags)
+            phase_run_inject(command, env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, path=args.path, tags=args.tags)
         elif args.command == 'console':
             phase_open_console()
         elif args.command == 'docs':
@@ -290,19 +299,19 @@ def main ():
                 sys.exit(1)
         elif args.command == 'secrets':
             if args.secrets_command == 'list':
-                phase_list_secrets(args.show, env_name=args.env, phase_app=args.app, path=args.path, tags=args.tags)
+                phase_list_secrets(args.show, env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, path=args.path, tags=args.tags)
             elif args.secrets_command == 'get':
-                phase_secrets_get(args.key, env_name=args.env, phase_app=args.app, path=args.path, tags=args.tags)  
+                phase_secrets_get(args.key, env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, path=args.path, tags=args.tags)  
             elif args.secrets_command == 'create':
-                phase_secrets_create(args.key, env_name=args.env, phase_app=args.app, path=args.path, random_type=args.random, random_length=args.length, override=args.override)
+                phase_secrets_create(args.key, env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, path=args.path, random_type=args.random, random_length=args.length, override=args.override)
             elif args.secrets_command == 'delete':
-                phase_secrets_delete(args.keys, env_name=args.env, path=args.path, phase_app=args.app)  
+                phase_secrets_delete(args.keys, env_name=args.env, path=args.path, phase_app=args.app, phase_app_id=args.app_id)  
             elif args.secrets_command == 'import':
-                phase_secrets_env_import(args.env_file, env_name=args.env, path=args.path, phase_app=args.app)
+                phase_secrets_env_import(args.env_file, env_name=args.env, path=args.path, phase_app=args.app, phase_app_id=args.app_id)
             elif args.secrets_command == 'export':
-                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, path=args.path, tags=args.tags, format=args.format)
+                phase_secrets_env_export(env_name=args.env, keys=args.keys, phase_app=args.app, phase_app_id=args.app_id, path=args.path, tags=args.tags, format=args.format)
             elif args.secrets_command == 'update':
-                phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, source_path=args.path, destination_path=args.updated_path, random_type=args.random, random_length=args.length, override=args.override, toggle_override=args.toggle_override)
+                phase_secrets_update(args.key, env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, source_path=args.path, destination_path=args.updated_path, random_type=args.random, random_length=args.length, override=args.override, toggle_override=args.toggle_override)
             else:
                 print("Unknown secrets sub-command: " + args.secrets_command)
                 parser.print_help()

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.18.4"
+__version__ = "1.18.5"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -302,7 +302,7 @@ def phase_get_context(user_data, app_name=None, env_name=None, app_id=None):
     - user_data (dict): The user data from the API response.
     - app_name (str, optional): The name (or partial name) of the desired application.
     - env_name (str, optional): The name (or partial name) of the desired environment.
-    - app_id (str, optional): The explicit application ID to use.
+    - app_id (str, optional): The explicit application ID to use. Takes precedence over app_name if both are provided.
     
     Returns:
     - tuple: A tuple containing the application's name, application's ID, environment's name, environment's ID, and publicKey.
@@ -311,7 +311,7 @@ def phase_get_context(user_data, app_name=None, env_name=None, app_id=None):
     - ValueError: If no matching application or environment is found.
     """
     # 1. Get the default app_id and env_name from .phase.json if no explicit app_id provided
-    if not app_id:
+    if not app_id and not app_name:
         try:
             with open(PHASE_ENV_CONFIG, 'r') as f:
                 config_data = json.load(f)
@@ -327,22 +327,21 @@ def phase_get_context(user_data, app_name=None, env_name=None, app_id=None):
     # 2. If env_name isn't explicitly provided, use the default
     env_name = env_name or default_env_name
 
-    # 3. Match the application using app_id or find the best match for partial app_name
+    # 3. Match the application using app_id first, then fall back to app_name if app_id is not provided
     try:
-        if app_name:
+        if app_id:  # app_id takes precedence
+            application = next((app for app in user_data["apps"] if app["id"] == app_id), None)
+            if not application:
+                raise ValueError(f"🔍 No application found with ID: '{app_id}'.")
+        elif app_name:  # only check app_name if app_id is not provided
             matching_apps = [app for app in user_data["apps"] if app_name.lower() in app["name"].lower()]
             if not matching_apps:
                 raise ValueError(f"🔍 No application found with the name '{app_name}'.")
             # Sort matching applications by the length of their names, shorter names are likely to be more specific matches
             matching_apps.sort(key=lambda app: len(app["name"]))
             application = matching_apps[0]
-        elif app_id:
-            application = next((app for app in user_data["apps"] if app["id"] == app_id), None)
-            if not application:
-                app_name_display = app_name_from_config if not app_id else f"ID: '{app_id}'"
-                raise ValueError(f"🔍 No application found with {app_name_display}.")
         else:
-            raise ValueError("🤔 No application context provided. Please run 'phase init' or pass the '--app' flag followed by your application name.")
+            raise ValueError("🤔 No application context provided. Please run 'phase init' or pass the '--app' or '--app-id' flag.")
 
         # 4. Attempt to match environment with the exact name or a name that contains the env_name string
         environment = next((env for env in application["environment_keys"] if env_name.lower() in env["environment"]["name"].lower()), None)

--- a/phase_cli/utils/phase_io.py
+++ b/phase_cli/utils/phase_io.py
@@ -101,14 +101,15 @@ class Phase:
         return response.json()
 
 
-    def create(self, key_value_pairs: List[Tuple[str, str]], env_name: str, app_name: str, path: str = '/', override_value: str = None) -> requests.Response:
+    def create(self, key_value_pairs: List[Tuple[str, str]], env_name: str, app_name: str = None, app_id: str = None, path: str = '/', override_value: str = None) -> requests.Response:
         """
         Create secrets in Phase KMS with support for specifying a path and overrides.
 
         Args:
             key_value_pairs (List[Tuple[str, str]]): List of tuples where each tuple contains a key and a value.
             env_name (str): The name (or partial name) of the desired environment.
-            app_name (str): The name of the application context.
+            app_name (str, optional): The name of the application context.
+            app_id (str, optional): The explicit application ID to use.
             path (str, optional): The path under which to store the secrets. Defaults to the root path '/'.
             override_value (str, optional): The overridden value for the secret. Defaults to None.
 
@@ -120,7 +121,7 @@ class Phase:
             raise ValueError(f"Request failed with status code {user_response.status_code}: {user_response.text}")
 
         user_data = user_response.json()
-        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name)
+        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name, app_id=app_id)
 
         environment_key = self._find_matching_environment_key(user_data, env_id)
         if environment_key is None:
@@ -156,7 +157,7 @@ class Phase:
         return create_phase_secrets(self._token_type, self._app_secret.app_token, env_id, secrets, self._api_host)
 
 
-    def get(self, env_name: str, keys: List[str] = None, app_name: str = None, tag: str = None, path: str = '') -> List[Dict]:
+    def get(self, env_name: str, keys: List[str] = None, app_name: str = None, app_id: str = None, tag: str = None, path: str = '') -> List[Dict]:
         """
         Get secrets from Phase KMS based on key and environment, with support for personal overrides,
         optional tag matching, decrypting comments, and now including path support and key digest optimization.
@@ -165,6 +166,7 @@ class Phase:
             env_name (str): The name (or partial name) of the desired environment.
             keys (List[str], optional): The keys for which to retrieve the secret values.
             app_name (str, optional): The name of the desired application.
+            app_id (str, optional): The explicit application ID to use.
             tag (str, optional): The tag to match against the secrets.
             path (str, optional): The path under which to fetch secrets, default is root.
 
@@ -177,7 +179,7 @@ class Phase:
             raise ValueError(f"Request failed with status code {user_response.status_code}: {user_response.text}")
 
         user_data = user_response.json()
-        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name)
+        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name, app_id=app_id)
 
         environment_key = self._find_matching_environment_key(user_data, env_id)
         if environment_key is None:
@@ -237,7 +239,7 @@ class Phase:
         return results
 
 
-    def update(self, env_name: str, key: str, value: str = None, app_name: str = None, source_path: str = '', destination_path: str = None, override: bool = False, toggle_override: bool = False) -> str:
+    def update(self, env_name: str, key: str, value: str = None, app_name: str = None, app_id: str = None, source_path: str = '', destination_path: str = None, override: bool = False, toggle_override: bool = False) -> str:
         """
         Update a secret in Phase KMS based on key and environment, with support for source and destination paths.
         
@@ -246,6 +248,7 @@ class Phase:
             key (str): The key for which to update the secret value.
             value (str, optional): The new value for the secret. Defaults to None.
             app_name (str, optional): The name of the desired application.
+            app_id (str, optional): The explicit application ID to use.
             source_path (str, optional): The current path of the secret. Defaults to root path '/'.
             destination_path (str, optional): The new path for the secret, if changing its location. If not provided, the path is not updated.
             override (bool, optional): Whether to update an overridden secret value. Defaults to False.
@@ -260,7 +263,7 @@ class Phase:
             raise ValueError(f"Request failed with status code {user_response.status_code}: {user_response.text}")
 
         user_data = user_response.json()
-        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name)
+        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name, app_id=app_id)
 
         environment_key = self._find_matching_environment_key(user_data, env_id)
         if environment_key is None:
@@ -344,7 +347,7 @@ class Phase:
             return f"Error: Failed to update secret. HTTP Status Code: {response.status_code}"
 
 
-    def delete(self, env_name: str, keys_to_delete: List[str], app_name: str = None, path: str = None) -> List[str]:
+    def delete(self, env_name: str, keys_to_delete: List[str], app_name: str = None, app_id: str = None, path: str = None) -> List[str]:
         """
         Delete secrets in Phase KMS based on keys and environment, with optional path support.
         
@@ -352,6 +355,7 @@ class Phase:
             env_name (str): The name (or partial name) of the desired environment.
             keys_to_delete (List[str]): The keys for which to delete the secrets.
             app_name (str, optional): The name of the desired application.
+            app_id (str, optional): The explicit application ID to use.
             path (str, optional): The path within which to delete the secrets. If specified, only deletes secrets within this path.
                 
         Returns:
@@ -363,7 +367,7 @@ class Phase:
             raise ValueError(f"Request failed with status code {user_response.status_code}: {user_response.text}")
 
         user_data = user_response.json()
-        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name)
+        app_name, app_id, env_name, env_id, public_key = phase_get_context(user_data, app_name=app_name, env_name=env_name, app_id=app_id)
 
         environment_key = self._find_matching_environment_key(user_data, env_id)
         if environment_key is None:


### PR DESCRIPTION
## Overview
This PR adds the ability to directly specify an application ID using the `--app-id` flag across the following commands:

phase secrets:
- create
- get
- update
- delete
- list
- export
- import

phase:
- run

This feature allows users to bypass name-based application lookup, making the CLI more robust when dealing with applications that might have similar names.

## Key Changes
- Added `--app-id` flag support to all relevant commands:
  - `phase run`
  - `phase secrets create/update/delete/list/get/import/export`
- Modified `phase_get_context` to prioritize `app_id` over `app_name` when both are provided
- Updated test suite to verify app ID functionality

## Usage
```fish
# Using app ID directly
phase secrets list --app-id dc371163-6735-49d2-a25a-2ce0fc3e147d --env dev

# App ID takes precedence when both are specified
phase secrets get SECRET_KEY --app "MyApp" --app-id dc371163-6735-49d2-a25a-2ce0fc3e147d --env dev  # Will use dc371163-6735-49d2-a25a-2ce0fc3e147d
```

## Testing
- Added new test cases to verify app ID functionality
- Updated existing tests to accommodate the new parameter
- Manually verified all affected commands

## Backwards Compatibility
This change is fully backwards compatible:
- All existing commands continue to work as before
- The `--app` flag remains supported and works as expected when `--app-id` is not provided