### PR TITLE
feat: add kv export format

### DIFF
--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -16,7 +16,8 @@ def phase_secrets_env_export(env_name=None, phase_app=None, phase_app_id=None, k
     This function fetches secrets from Phase, resolves any cross-environment or local secret references, and then outputs them in the chosen format.
 
     Supports several formats for exporting secrets:
-    - dotenv (.env): Key-value pairs in a simple text format.
+    - dotenv (.env): Key-value pairs in a simple text format with values wrapped in double quotes.
+    - KV: Simple key-value pairs. Upper case keys, raw values.
     - JSON: JavaScript Object Notation, useful for integration with various tools and languages.
     - CSV: Comma-Separated Values, a simple text format for tabular data.
     - YAML: Human-readable data serialization format, often used for configuration files.

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -37,7 +37,7 @@ def phase_secrets_env_export(env_name=None, phase_app=None, phase_app_id=None, k
                               these tags will be fetched. Defaults to None.
         format (str, optional): The format for exporting the secrets. Supported formats include 
                                 'dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 
-                                and 'java_properties'. Defaults to 'dotenv'.
+                                'java_properties', and 'kv'. Defaults to 'dotenv'.
 
     Raises:
         ValueError: If any errors occur during the fetching of secrets or if the specified format 
@@ -106,6 +106,8 @@ def phase_secrets_env_export(env_name=None, phase_app=None, phase_app_id=None, k
             export_ini(filtered_secrets_dict)
         elif format == 'java_properties':
             export_java_properties(filtered_secrets_dict)
+        elif format == 'kv':
+            export_kv(filtered_secrets_dict)
         else:
             export_dotenv(filtered_secrets_dict)
 
@@ -172,5 +174,11 @@ def export_ini(secrets_dict):
 
 def export_java_properties(secrets_dict):
     """Export secrets as Java properties file."""
+    for key, value in secrets_dict.items():
+        print(f'{key}={value}')
+
+
+def export_kv(secrets_dict):
+    """Export secrets as simple key-value pairs without quotes."""
     for key, value in secrets_dict.items():
         print(f'{key}={value}')

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -7,7 +7,6 @@ from phase_cli.utils.phase_io import Phase
 import xml.sax.saxutils as saxutils
 from phase_cli.utils.secret_referencing import resolve_all_secrets
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, BarColumn, TextColumn
 
 
 def phase_secrets_env_export(env_name=None, phase_app=None, phase_app_id=None, keys=None, tags=None, format='dotenv', path: str = ''):

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -238,7 +238,9 @@ def main ():
         secrets_export_parser.add_argument('--app', type=str, help=app_help)
         secrets_export_parser.add_argument('--app-id', type=str, help=app_id_help)
         secrets_export_parser.add_argument('--path', type=str, default='/', help="The path from which you want to export secret(s). Default is '/'")
-        secrets_export_parser.add_argument('--format', type=str, default='dotenv', choices=['dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 'java_properties'], help='Specifies the export format. Supported formats: dotenv (default), json, csv, yaml, xml, toml, hcl, ini, java_properties.')
+        secrets_export_parser.add_argument('--format', type=str, default='dotenv', 
+            choices=['dotenv', 'json', 'csv', 'yaml', 'xml', 'toml', 'hcl', 'ini', 'java_properties', 'kv'], 
+            help='Specifies the export format. Supported formats: dotenv (default), kv, json, csv, yaml, xml, toml, hcl, ini, java_properties.')
         secrets_export_parser.add_argument('--tags', type=str, help=tag_help)
 
         # Users command

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.18.6"
+__version__ = "1.18.7"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."


### PR DESCRIPTION
This PR adds a `kv` export type to the `phase secrets export` command (ex. `phase secrets export --format kv`). The KV export type will return secrets as simple key-value pairs, with the keys being capitalized and the values being returned as-is without being wrapped in double quotes, unlike the current default dotenv export type.

```
phase secrets export --format kv
FOO=bar
KEY_1=value_1
KEY_2=value_2
```

Ref: https://github.com/phasehq/console/issues/466
