### PR TITLE
feat: mono repo support

### DIFF
--- a/phase_cli/cmd/init.py
+++ b/phase_cli/cmd/init.py
@@ -50,6 +50,9 @@ def phase_init():
 
         env_id = env_choice_map[selected_env]
         selected_env_name = selected_env
+        
+        # Ask the user if they want this configuration to apply to subdirectories
+        apply_to_subdirs = questionary.confirm("🍱 Monorepo support: Would you like this configuration to apply to subdirectories?", default=False).ask()
 
         # Save the selected app's and environment's details to .phase.json
         phase_env = {
@@ -57,7 +60,8 @@ def phase_init():
             "phaseApp": selected_app_name,
             "appId": selected_app_details['id'],
             "defaultEnv": selected_env_name,
-            "envId": env_id
+            "envId": env_id,
+            "monorepoSupport": apply_to_subdirs
         }
 
         # Create .phase.json

--- a/phase_cli/cmd/open_console.py
+++ b/phase_cli/cmd/open_console.py
@@ -1,7 +1,5 @@
 import os
-import json
-import webbrowser
-from phase_cli.utils.misc import get_default_user_host, get_default_user_org, open_browser
+from phase_cli.utils.misc import get_default_user_host, get_default_user_org, open_browser, find_phase_config
 from phase_cli.utils.const import PHASE_SECRETS_DIR
 
 def phase_open_console():
@@ -11,18 +9,16 @@ def phase_open_console():
         config_file_path = os.path.join(PHASE_SECRETS_DIR, 'config.json')
         org_name = get_default_user_org(config_file_path)
         
-        phase_env_config_path = os.path.join(os.getcwd(), ".phase.json")
-        if os.path.exists(phase_env_config_path):
-            with open(phase_env_config_path, 'r') as file:
-                config = json.load(file)
-                app_id = config.get("appId")
-                version = int(config.get("version", "1"))  # Default to version 1 if not specified
-                
-                if version >= 2 and "envId" in config:
-                    env_id = config.get("envId")
-                    url = f"{url_base}/{org_name}/apps/{app_id}/environments/{env_id}"
-                else:
-                    url = f"{url_base}/{org_name}/apps/{app_id}"
+        config = find_phase_config()
+        if config:
+            app_id = config.get("appId")
+            version = int(config.get("version", "1"))  # Default to version 1 if not specified
+            
+            if version >= 2 and "envId" in config:
+                env_id = config.get("envId")
+                url = f"{url_base}/{org_name}/apps/{app_id}/environments/{env_id}"
+            else:
+                url = f"{url_base}/{org_name}/apps/{app_id}"
         else:
             url = url_base
         

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -71,18 +71,6 @@ def censor_secret(secret, max_length):
     return censored
 
 
-# Tokenizing function
-def tokenize(value):
-    delimiters = [':', '@', '/', ' ']
-    tokens = [value]
-    for delimiter in delimiters:
-        new_tokens = []
-        for token in tokens:
-            new_tokens.extend(token.split(delimiter))
-        tokens = new_tokens
-    return tokens
-
-
 def render_tree_with_tables(data, show, console):
     """
     Organize secrets by path and render a table for each path within a tree structure,

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -300,13 +300,12 @@ def phase_get_context(user_data, app_name=None, env_name=None, app_id=None):
     """
     # 1. Get the default app_id and env_name from .phase.json if no explicit app_id provided
     if not app_id and not app_name:
-        try:
-            with open(PHASE_ENV_CONFIG, 'r') as f:
-                config_data = json.load(f)
+        config_data = find_phase_config()
+        if config_data:
             default_env_name = config_data.get("defaultEnv")
             app_name_from_config = config_data.get("phaseApp")
             app_id = config_data.get("appId")
-        except FileNotFoundError:
+        else:
             default_env_name = "Development"
             app_id = None
     else:
@@ -341,6 +340,54 @@ def phase_get_context(user_data, app_name=None, env_name=None, app_id=None):
         return (application["name"], application["id"], environment["environment"]["name"], environment["environment"]["id"], environment["identity_key"])
     except StopIteration:
         raise ValueError("🔍 Application or environment not found.")
+
+
+def find_phase_config(max_depth=8):
+    """
+    Search for a .phase.json file in the current directory and parent directories.
+    
+    Parameters:
+    - max_depth (int): Maximum number of parent directories to check. Can be overridden with PHASE_CONFIG_PARENT_DIR_SEARCH_DEPTH environment variable.
+    
+    Returns:
+    - dict or None: The contents of the .phase.json file if found, None otherwise.
+    """
+    # Check for environment variable override for search depth
+    try:
+        env_depth = os.environ.get('PHASE_CONFIG_PARENT_DIR_SEARCH_DEPTH')
+        if env_depth:
+            max_depth = int(env_depth)
+    except (ValueError, TypeError):
+        # If conversion fails, keep using the default max_depth
+        pass
+    
+    current_dir = os.getcwd()
+    original_dir = current_dir
+    
+    # Try up to max_depth parent directories
+    for _ in range(max_depth + 1):  # +1 to include current directory
+        config_path = os.path.join(current_dir, PHASE_ENV_CONFIG)
+        
+        if os.path.exists(config_path):
+            try:
+                with open(config_path, 'r') as f:
+                    config_data = json.load(f)
+                # Only use this config if monorepoSupport is true or we're in the original directory
+                if os.path.samefile(current_dir, original_dir) or config_data.get("monorepoSupport", False):
+                    return config_data
+            except (json.JSONDecodeError, FileNotFoundError, OSError):
+                pass
+        
+        # Move up to the parent directory
+        parent_dir = os.path.dirname(current_dir)
+        
+        # If we've reached the root directory, stop
+        if parent_dir == current_dir:
+            break
+            
+        current_dir = parent_dir
+    
+    return None
 
 
 def normalize_tag(tag):

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -303,7 +303,6 @@ def phase_get_context(user_data, app_name=None, env_name=None, app_id=None):
         config_data = find_phase_config()
         if config_data:
             default_env_name = config_data.get("defaultEnv")
-            app_name_from_config = config_data.get("phaseApp")
             app_id = config_data.get("appId")
         else:
             default_env_name = "Development"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,167 @@
+import os
+import json
+import pytest
+import tempfile
+import shutil
+from unittest.mock import patch
+
+from phase_cli.utils.misc import find_phase_config
+from phase_cli.utils.const import PHASE_ENV_CONFIG
+
+class TestFindPhaseConfig:
+    """Test find_phase_config"""
+    
+    @pytest.fixture
+    def setup_test_dirs(self):
+        """Create a temporary directory structure for testing."""
+        # Create a temporary base directory
+        base_dir = tempfile.mkdtemp()
+        
+        # Create nested directories
+        parent_dir = os.path.join(base_dir, "parent")
+        child_dir = os.path.join(parent_dir, "child")
+        grandchild_dir = os.path.join(child_dir, "grandchild")
+        
+        os.makedirs(parent_dir)
+        os.makedirs(child_dir)
+        os.makedirs(grandchild_dir)
+        
+        # Return the directory paths and a cleanup function
+        yield base_dir, parent_dir, child_dir, grandchild_dir
+        
+        # Cleanup after test
+        shutil.rmtree(base_dir)
+    
+    def mock_phase_config(self, directory, monorepo_support=False):
+        """Helper to create a .phase.json file in a directory."""
+        config = {
+            "version": "2",
+            "phaseApp": "TestApp",
+            "appId": "00000000-0000-0000-0000-000000000000",
+            "defaultEnv": "Development",
+            "envId": "00000000-0000-0000-0000-000000000001",
+            "monorepoSupport": monorepo_support
+        }
+        
+        config_path = os.path.join(directory, PHASE_ENV_CONFIG)
+        with open(config_path, 'w') as f:
+            json.dump(config, f)
+        
+        return config
+    
+    def test_find_config_in_current_dir(self, setup_test_dirs):
+        """Test finding config in the current directory."""
+        _, parent_dir, _, _ = setup_test_dirs
+        expected_config = self.mock_phase_config(parent_dir)
+        
+        with patch('os.getcwd', return_value=parent_dir):
+            config = find_phase_config()
+            assert config == expected_config
+    
+    def test_find_config_in_parent_dir_with_monorepo_support(self, setup_test_dirs):
+        """Test finding config in a parent directory with monorepoSupport=True."""
+        _, parent_dir, _, grandchild_dir = setup_test_dirs
+        expected_config = self.mock_phase_config(parent_dir, monorepo_support=True)
+        
+        with patch('os.getcwd', return_value=grandchild_dir):
+            config = find_phase_config()
+            assert config == expected_config
+    
+    def test_find_config_in_parent_dir_without_monorepo_support(self, setup_test_dirs):
+        """Test finding config in a parent directory with monorepoSupport=False."""
+        _, parent_dir, _, grandchild_dir = setup_test_dirs
+        self.mock_phase_config(parent_dir, monorepo_support=False)
+        
+        with patch('os.getcwd', return_value=grandchild_dir):
+            config = find_phase_config()
+            assert config is None
+    
+    def test_max_depth_parameter(self, setup_test_dirs):
+        """Test respecting the max_depth parameter."""
+        _, parent_dir, child_dir, grandchild_dir = setup_test_dirs
+        expected_config = self.mock_phase_config(parent_dir, monorepo_support=True)
+        
+        # Test with max_depth=1 (should not find config in parent)
+        with patch('os.getcwd', return_value=grandchild_dir):
+            config = find_phase_config(max_depth=1)
+            assert config is None
+        
+        # Test with max_depth=2 (should find config in parent)
+        with patch('os.getcwd', return_value=grandchild_dir):
+            config = find_phase_config(max_depth=2)
+            assert config == expected_config
+    
+    def test_env_variable_override(self, setup_test_dirs):
+        """Test respecting the PHASE_CONFIG_PARENT_DIR_SEARCH_DEPTH environment variable."""
+        _, parent_dir, child_dir, grandchild_dir = setup_test_dirs
+        expected_config = self.mock_phase_config(parent_dir, monorepo_support=True)
+        
+        # Test with environment variable set to 1 (should not find config in parent)
+        with patch('os.getcwd', return_value=grandchild_dir), \
+             patch.dict('os.environ', {'PHASE_CONFIG_PARENT_DIR_SEARCH_DEPTH': '1'}):
+            config = find_phase_config()
+            assert config is None
+        
+        # Test with environment variable set to 2 (should find config in parent)
+        with patch('os.getcwd', return_value=grandchild_dir), \
+             patch.dict('os.environ', {'PHASE_CONFIG_PARENT_DIR_SEARCH_DEPTH': '2'}):
+            config = find_phase_config()
+            assert config == expected_config
+    
+    def test_no_config_found(self, setup_test_dirs):
+        """Test that None is returned when no config is found."""
+        base_dir, _, _, _ = setup_test_dirs
+        
+        with patch('os.getcwd', return_value=base_dir):
+            config = find_phase_config()
+            assert config is None
+            
+    def test_invalid_json_config(self, setup_test_dirs):
+        """Test handling of invalid JSON in config file."""
+        _, parent_dir, _, _ = setup_test_dirs
+        
+        # Create an invalid JSON file
+        config_path = os.path.join(parent_dir, PHASE_ENV_CONFIG)
+        with open(config_path, 'w') as f:
+            f.write("{invalid json}")
+        
+        with patch('os.getcwd', return_value=parent_dir):
+            config = find_phase_config()
+            assert config is None
+    
+    def test_file_not_found_error(self):
+        """Test handling of FileNotFoundError when trying to open config."""
+        mock_path_exists = patch('os.path.exists', return_value=True)
+        mock_file_open = patch('builtins.open', side_effect=FileNotFoundError)
+        
+        with patch('os.getcwd', return_value='/fake/path'), mock_path_exists, mock_file_open:
+            config = find_phase_config()
+            assert config is None
+    
+    def test_os_error(self):
+        """Test handling of OSError when trying to open config."""
+        mock_path_exists = patch('os.path.exists', return_value=True)
+        mock_file_open = patch('builtins.open', side_effect=OSError)
+        
+        with patch('os.getcwd', return_value='/fake/path'), mock_path_exists, mock_file_open:
+            config = find_phase_config()
+            assert config is None
+            
+    def test_reach_root_directory(self):
+        """Test that the function stops when reaching the root directory."""
+        # Define a custom side effect function for os.path.dirname
+        def dirname_side_effect(path):
+            if path == '/fakepath/path':
+                return '/fakepath'
+            elif path == '/fakepath':
+                return '/'
+            else:
+                return '/'  # Keep returning root for any additional calls
+        
+        # Mock the directory structure to simulate reaching root
+        with patch('os.getcwd', return_value='/fakepath/path'), \
+             patch('os.path.exists', return_value=False), \
+             patch('os.path.dirname', side_effect=dirname_side_effect), \
+             patch('os.path.samefile', return_value=False):
+            config = find_phase_config(max_depth=10)
+            assert config is None 


### PR DESCRIPTION
# Monorepo Support

## Overview

This PR adds monorepo support to the Phase CLI. Users can now Phase config context inside of _n_ number of sub-directories. 

Ref: https://github.com/phasehq/cli/issues/183

## How It Works

When users run `phase init` they will be asked if they want to enabled monorepo support:

```bash
phase init      
? Select an App: example-app (7d8169ad-f15c-4517-b307-0b5f45099c6b)
? Choose a Default Environment: Development
? 🍱 Monorepo support: Would you like this configuration to apply to subdirectories? (y/N)
```

If they select Yes, the `.phase.json` config will be initialize with `"monorepoSupport": null`. The Phase CLI will for scan parent directories containing a `.phase.json` config with monorepo enabled, if one is found that config will be used. By default the CLI will search for the config in parent directories up to depth 8, this can also be set by the user by setting the `PHASE_CONFIG_PARENT_DIR_SEARCH_DEPTH` environment variable.

### Example Usage

1. **During initialization**:
   ```
   $ phase init
   # [...other prompts...]
   🍱 Monorepo support: Would you like this configuration to apply to subdirectories? [y/N]: y
   ```

2. **Project Structure**:
   ```
   monorepo/
   ├── .phase.json (with "monorepoSupport": true)
   ├── service-a/
   │   └── src/
   └── service-b/
       └── src/
   ```

## Backwards Compatibility

This change maintains backward compatibility with existing `.phase.json` configurations. There isn't a need to bump the Phase config version. The `find_phase_config` function defaults to `False` for the `monorepoSupport` key if it isn't present, ensuring previous behavior for existing users.