### PR TITLE
fix: use snake case to comply with pypi naming convention

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('requirements.txt') as f:
 version = __version__
 
 setup(
-    name='phase-cli',
+    name='phase_cli',
     version=version,
     author='Phase',
     author_email='info@phase.dev',


### PR DESCRIPTION
Addresses: https://github.com/phasehq/cli/issues/180