### PR TITLE
feat: cli command error codes

### DIFF
--- a/phase_cli/cmd/open_console.py
+++ b/phase_cli/cmd/open_console.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from phase_cli.utils.misc import get_default_user_host, get_default_user_org, open_browser, find_phase_config
 from phase_cli.utils.const import PHASE_SECRETS_DIR
 
@@ -25,3 +26,4 @@ def phase_open_console():
         open_browser(url)
     except Exception as e:
         print(f"Error opening Phase console: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/open_docs.py
+++ b/phase_cli/cmd/open_docs.py
@@ -1,6 +1,11 @@
-import os
+import sys
 import webbrowser
 
 def phase_open_docs():
-    url = "https://docs.phase.dev/cli/commands"
-    webbrowser.open(url)
+    """Opens the Phase documentation in a web browser"""
+    try:
+        url = "https://docs.phase.dev/cli/commands"
+        webbrowser.open(url)
+    except Exception as e:
+        print(f"Error opening Phase documentation: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -65,7 +65,10 @@ def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, 
 
                 # Print the message with the number of secrets injected
                 console.log(f"🚀 Injected [bold magenta]{secret_count}[/] secrets from the [bold green]{environment_message}[/] environment.\n")
-                subprocess.run(command, shell=True, env=new_env)
+                process = subprocess.run(command, shell=True, env=new_env)
+                
+                # Exit with the same code as the subprocess
+                sys.exit(process.returncode)
 
     except ValueError as e:
         console.log(f"Error: {e}")

--- a/phase_cli/cmd/secrets/create.py
+++ b/phase_cli/cmd/secrets/create.py
@@ -42,7 +42,7 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, phase_app_id=N
             value = generate_random_secret(random_type, random_length)
         except ValueError as e:
             console.log(f"Error: {e}")
-            return
+            sys.exit(1)
     else:
         # Check if input is being piped
         if sys.stdin.isatty():
@@ -67,6 +67,8 @@ def phase_secrets_create(key=None, env_name=None, phase_app=None, phase_app_id=N
         else:
             # Print an error message if the response status code indicates an error
             console.log(f"Error: Failed to create secret. HTTP Status Code: {response.status_code}")
+            sys.exit(1)
 
     except ValueError as e:
         console.log(f"Error: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/secrets/delete.py
+++ b/phase_cli/cmd/secrets/delete.py
@@ -1,3 +1,4 @@
+import sys
 from phase_cli.utils.phase_io import Phase
 from phase_cli.cmd.secrets.list import phase_list_secrets
 from rich.console import Console
@@ -39,3 +40,4 @@ def phase_secrets_delete(keys_to_delete: List[str] = None, env_name: str = None,
     
     except ValueError as e:
         console.log(f"Error: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -113,6 +113,7 @@ def phase_secrets_env_export(env_name=None, phase_app=None, phase_app_id=None, k
 
     except ValueError as e:
         console.log(f"Error: {e}")
+        sys.exit(1)
 
 
 def export_json(secrets_dict):

--- a/phase_cli/cmd/secrets/export.py
+++ b/phase_cli/cmd/secrets/export.py
@@ -85,6 +85,12 @@ def phase_secrets_env_export(env_name=None, phase_app=None, phase_app_id=None, k
 
         # Filter secrets if specific keys are requested
         if keys:
+            # Check if any requested keys don't exist
+            missing_keys = [key for key in keys if key not in all_secrets_dict]
+            if missing_keys:
+                console.log(f"Error: 🥡 Failed to export. The following secret(s) do not exist: {', '.join(missing_keys)}")
+                sys.exit(1)
+                
             filtered_secrets_dict = {key: all_secrets_dict[key] for key in keys if key in all_secrets_dict}
         else:
             filtered_secrets_dict = all_secrets_dict

--- a/phase_cli/cmd/secrets/get.py
+++ b/phase_cli/cmd/secrets/get.py
@@ -1,3 +1,4 @@
+import sys
 from phase_cli.utils.phase_io import Phase
 from rich.console import Console
 import json
@@ -26,7 +27,7 @@ def phase_secrets_get(key, env_name=None, phase_app=None, phase_app_id=None, tag
         # Check that secret_data was found and is a dictionary
         if not secret_data:
             console.log("🔍 Secret not found...")
-            return
+            sys.exit(1)
         if not isinstance(secret_data, dict):
             raise ValueError("Unexpected format: secret data is not a dictionary")
         
@@ -36,3 +37,4 @@ def phase_secrets_get(key, env_name=None, phase_app=None, phase_app_id=None, tag
 
     except ValueError as e:
         console.log(f"Error: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/secrets/import_env.py
+++ b/phase_cli/cmd/secrets/import_env.py
@@ -49,6 +49,8 @@ def phase_secrets_env_import(env_file, env_name=None, phase_app=None, phase_app_
         else:
             # Print an error message if the response status code indicates an error
             console.log(f"Error: Failed to import secrets. HTTP Status Code: {response.status_code}")
+            sys.exit(1)
 
     except ValueError as e:
         console.log(f"Error: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/secrets/list.py
+++ b/phase_cli/cmd/secrets/list.py
@@ -1,3 +1,4 @@
+import sys
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.misc import render_tree_with_tables
 from rich.console import Console
@@ -36,3 +37,4 @@ def phase_list_secrets(show=False, env_name=None, phase_app=None, phase_app_id=N
 
     except ValueError as e:
         console.log(f"Error: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/secrets/update.py
+++ b/phase_cli/cmd/secrets/update.py
@@ -44,7 +44,7 @@ def phase_secrets_update(key, env_name=None, phase_app=None, phase_app_id=None, 
             new_value = generate_random_secret(random_type, random_length)
         except ValueError as e:
             console.log(f"Error: {e}")
-            return
+            sys.exit(1)
     elif not override:
         if sys.stdin.isatty():
             new_value = getpass.getpass(f"✨ Please enter the new value for {key} (hidden): ")
@@ -75,3 +75,4 @@ def phase_secrets_update(key, env_name=None, phase_app=None, phase_app_id=None, 
             console.log(f"{response}")
     except ValueError as e:
         console.log(f"⚠️  Error occurred while updating the secret: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/update.py
+++ b/phase_cli/cmd/update.py
@@ -1,6 +1,7 @@
 import requests
 import subprocess
 import os
+import sys
 
 def phase_cli_update():
     # URL of the remote bash script
@@ -27,7 +28,10 @@ def phase_cli_update():
         print("Update completed successfully.")
     except requests.RequestException as e:
         print(f"Error fetching the update script: {e}")
+        sys.exit(1)
     except subprocess.CalledProcessError:
         print("Error executing the update script.")
+        sys.exit(1)
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/users/keyring.py
+++ b/phase_cli/cmd/users/keyring.py
@@ -1,9 +1,14 @@
 import keyring
+import sys
 
 def show_keyring_info():
-    kr = keyring.get_keyring()
-    print(f"Current keyring backend: {kr.__class__.__name__}")
-    print("Supported keyring backends:")
-    for backend in keyring.backend.get_all_keyring():
-        print(f"- {backend.__class__.__name__}")
+    try:
+        kr = keyring.get_keyring()
+        print(f"Current keyring backend: {kr.__class__.__name__}")
+        print("Supported keyring backends:")
+        for backend in keyring.backend.get_all_keyring():
+            print(f"- {backend.__class__.__name__}")
+    except Exception as e:
+        print(f"Error accessing keyring information: {e}")
+        sys.exit(1)
         

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 from questionary import select, Separator
 from phase_cli.utils.const import CONFIG_FILE
 
@@ -7,17 +8,25 @@ def load_config():
     if not os.path.exists(CONFIG_FILE):
         print("No configuration found. Please run 'phase auth' to set up your configuration.")
         return None
-    with open(CONFIG_FILE, 'r') as f:
-        return json.load(f)
+    try:
+        with open(CONFIG_FILE, 'r') as f:
+            return json.load(f)
+    except json.JSONDecodeError:
+        print("Error reading the config file. The file may be corrupted or not in the expected format.")
+        sys.exit(1)
 
 def save_config(config_data):
-    with open(CONFIG_FILE, 'w') as f:
-        json.dump(config_data, f, indent=4)
+    try:
+        with open(CONFIG_FILE, 'w') as f:
+            json.dump(config_data, f, indent=4)
+    except Exception as e:
+        print(f"Error saving configuration: {e}")
+        sys.exit(1)
 
 def switch_user():
     config_data = load_config()
     if not config_data:
-        return
+        sys.exit(1)
 
     # Prepare user choices, including a visual separator as a title.
     # Also, create a mapping for the partial UUID to the full UUID.
@@ -54,6 +63,9 @@ def switch_user():
                 break
             else:
                 print("User switch failed.")
-                break
+                sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(0)
+    except Exception as e:
+        print(f"Error switching user: {e}")
+        sys.exit(1)

--- a/phase_cli/cmd/users/whoami.py
+++ b/phase_cli/cmd/users/whoami.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from phase_cli.utils.const import CONFIG_FILE
 
 
@@ -16,14 +17,14 @@ def phase_users_whoami():
 
         if not default_user_id:
             print("No default user set.")
-            return
+            sys.exit(1)
 
         # Find the user details matching the default user ID
         default_user = next((user for user in config_data["phase-users"] if user["id"] == default_user_id), None)
         
         if not default_user:
             print("Default user not found in the users list.")
-            return
+            sys.exit(1)
 
         # Print the default user details
         print(f"✉️\u200A Email: {default_user['email']}")
@@ -33,5 +34,7 @@ def phase_users_whoami():
 
     except FileNotFoundError:
         print(f"Config file not found at {CONFIG_FILE}.")
+        sys.exit(1)
     except json.JSONDecodeError:
         print("Error reading the config file. The file may be corrupted or not in the expected format.")
+        sys.exit(1)

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -61,7 +61,7 @@ class HelpfulParser(argparse.ArgumentParser):
         print (description)
         print(phaseASCii)
         self.print_help()
-        sys.exit(2)
+        sys.exit(0)
 
     def add_subparsers(self, **kwargs):
         kwargs['title'] = 'Commands'

--- a/tests/secrets_get.py
+++ b/tests/secrets_get.py
@@ -1,0 +1,104 @@
+import unittest
+import json
+from unittest.mock import patch
+from phase_cli.cmd.secrets.get import phase_secrets_get
+
+class TestPhaseSecretsGet(unittest.TestCase):
+    
+    def setUp(self):
+        # Reset all mocks before each test to avoid interference between tests
+        self.patcher_console = patch('phase_cli.cmd.secrets.get.Console')
+        self.mock_console = self.patcher_console.start()
+        self.mock_console_instance = self.mock_console.return_value
+        
+        self.patcher_phase = patch('phase_cli.cmd.secrets.get.Phase')
+        self.mock_phase = self.patcher_phase.start()
+        self.mock_phase_instance = self.mock_phase.return_value
+        
+        self.patcher_exit = patch('phase_cli.cmd.secrets.get.sys.exit')
+        self.mock_exit = self.patcher_exit.start()
+    
+    def tearDown(self):
+        # Ensure all patches are properly stopped
+        self.patcher_console.stop()
+        self.patcher_phase.stop()
+        self.patcher_exit.stop()
+    
+    def test_phase_secrets_get_success(self):
+        # Mock the return value to simulate a successful secret fetch
+        mock_secret = {
+            "key": "TEST_KEY", 
+            "value": "test_value", 
+            "environment": "dev", 
+            "application": "test-app",
+            "path": "/"
+        }
+        self.mock_phase_instance.get.return_value = [mock_secret]
+        
+        # Spy on print function to verify output
+        with patch('builtins.print') as mock_print:
+            # Act: Call the function
+            phase_secrets_get("TEST_KEY", env_name="dev", phase_app="test-app")
+            
+            # Assert: Verify the correct output was printed
+            mock_print.assert_called_once_with(json.dumps(mock_secret, indent=4))
+            
+            # Verify sys.exit was not called (function completes normally)
+            self.mock_exit.assert_not_called()
+            
+            # Verify that Phase.get was called with correct args
+            self.mock_phase_instance.get.assert_called_once_with(
+                env_name="dev", 
+                keys=["TEST_KEY"], 
+                app_name="test-app", 
+                app_id=None, 
+                tag=None, 
+                path="/"
+            )
+    
+    def test_phase_secrets_get_secret_not_found(self):
+        # Mock the return value to simulate no secrets found
+        self.mock_phase_instance.get.return_value = []
+        
+        # Act: Call the function
+        phase_secrets_get("NONEXISTENT_KEY", env_name="dev", phase_app="test-app")
+        
+        # Assert: Verify error message was logged
+        # We'll check that the log was called with the right message without asserting exactly once
+        self.mock_console_instance.log.assert_any_call("🔍 Secret not found...")
+        
+        # Verify sys.exit was called with exit code 1
+        self.mock_exit.assert_any_call(1)
+    
+    def test_phase_secrets_get_invalid_format(self):
+        # Create a non-dictionary secret to test the error condition
+        self.mock_phase_instance.get.return_value = []
+        
+        # We need to make next() return a non-dictionary value
+        # Let's use patch to replace the next() call with a custom function
+        with patch('phase_cli.cmd.secrets.get.next', return_value="this is not a dict"):
+            # Act: Call the function
+            phase_secrets_get("TEST_KEY", env_name="dev", phase_app="test-app")
+            
+            # Assert: Verify error message was logged with the appropriate error
+            self.mock_console_instance.log.assert_any_call("Error: Unexpected format: secret data is not a dictionary")
+            
+            # Verify sys.exit was called with exit code 1
+            self.mock_exit.assert_any_call(1)
+    
+    def test_phase_secrets_get_api_error(self):
+        # Mock Phase.get to raise a ValueError (API error)
+        error_message = "API request failed"
+        self.mock_phase_instance.get.side_effect = ValueError(error_message)
+        
+        # Act: Call the function
+        phase_secrets_get("TEST_KEY", env_name="dev", phase_app="test-app")
+        
+        # Assert: Verify error message was logged
+        self.mock_console_instance.log.assert_called_once_with(f"Error: {error_message}")
+        
+        # Verify sys.exit was called with exit code 1
+        self.mock_exit.assert_any_call(1)
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This PR improves the way the Phase CLI handles exceptions and returns exit codes. This improves the scriptability of the CLI and improves it's operations in containerized environments.

Ref: https://github.com/phasehq/cli/issues/184

Before: 

```bash
phase secrets get A_SECRET_THAT_DOESNT_EXIST && echo $?
[15:07:37] 🔍 Secret not found...
0
```

After:

```bash
phase secrets get A_SECRET_THAT_DOESNT_EXIST && echo $?
[15:08:22] 🔍 Secret not found...
1
```

Changes made:
- Added / fixed error code statuses for the following commands:
  - phase run
  - phase secrets get
  - phase secrets export
  - phase secrets import
  - phase secrets list
  - phase secrets create
  - phase secrets update
  - phase secrets delete
  - phase console
  - phase update
  - phase docs
  - phase users
  - phase users keyring
  - phase users whoami
  - phase users switch

- Added / updated existing unit tests to check for exit codes for the following critical subcommands (scriptable) commands:
  - phase run
  - phase secrets get
  - phase secrets export

- Phase run now returns the correct exit code of the application that was run (subprocess).

Example:

```bash
# Exit code 1 (general error)
phase run "false"
echo "Exit code: $?"

Exit code: 1
[15:14:53] 🚀 Injected 15 secrets from the Development environment.    

# Custom exit code (42)
phase run "bash -c 'exit 42'"
echo "Exit code: $?"

Exit code: 42
[15:14:55] 🚀 Injected 15 secrets from the Development environment.

# Syntax error in a command
phase run "ls --invalid-flag" 
echo "Exit code: $?"
[15:14:52] 🚀 Injected 15 secrets from the Development environment.

ls: unrecognized option '--invalid-flag'
Try 'ls --help' for more information.
Exit code: 2 
```