### PR TITLE
feat: phase shell (beta)

### DIFF
--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -16,7 +16,9 @@ def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, 
         command (str): The shell command to be executed.
         env_name (str, optional): The environment name from which secrets are fetched. Defaults to None.
         phase_app (str, optional): The name of the Phase application. Defaults to None.
+        phase_app_id (str, optional): The ID of the Phase application. Defaults to None.
         tags (str, optional): Comma-separated list of tags to filter secrets. Defaults to None.
+        path (str, optional): Specific path under which to fetch secrets. Defaults to '/'.
     """
     phase = Phase()
     console = Console()
@@ -54,7 +56,12 @@ def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, 
 
                 # Count and get environment from the secrets for the message
                 secret_count = len(resolved_secrets_dict)
+                
+                # Extract application and environment names
+                applications = set(secret.get('application') for secret in all_secrets if secret['key'] in resolved_secrets_dict and secret.get('application'))
                 environments = set(secret.get('environment') for secret in all_secrets if secret['key'] in resolved_secrets_dict)
+                
+                application_message = ', '.join(applications)
                 environment_message = ', '.join(environments)
 
                 new_env = os.environ.copy()
@@ -64,7 +71,11 @@ def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, 
                 progress.stop()
 
                 # Print the message with the number of secrets injected
-                console.log(f"🚀 Injected [bold magenta]{secret_count}[/] secrets from the [bold green]{environment_message}[/] environment.\n")
+                if path and path != '/':
+                    console.log(f"🚀 Injected [bold magenta]{secret_count}[/] secrets from Application: [bold cyan]{application_message}[/], Environment: [bold green]{environment_message}[/], Path: [bold yellow]{path}[/]\n")
+                else:
+                    console.log(f"🚀 Injected [bold magenta]{secret_count}[/] secrets from Application: [bold cyan]{application_message}[/], Environment: [bold green]{environment_message}[/]\n")
+                
                 subprocess.run(command, shell=True, env=new_env)
 
     except ValueError as e:

--- a/phase_cli/cmd/shell.py
+++ b/phase_cli/cmd/shell.py
@@ -1,0 +1,111 @@
+import sys
+import os
+import subprocess
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn
+from phase_cli.utils.phase_io import Phase
+from phase_cli.utils.secret_referencing import resolve_all_secrets
+from phase_cli.utils.misc import get_default_shell, get_shell_command
+
+def phase_shell(env_name=None, phase_app=None, phase_app_id=None, tags=None, path: str = '/', shell_type=None):
+    """
+    Launches an interactive shell with environment variables set to the secrets 
+    fetched from Phase for the specified environment, resolving references as needed.
+
+    Args:
+        env_name (str, optional): The environment name from which secrets are fetched. Defaults to None.
+        phase_app (str, optional): The name of the Phase application. Defaults to None.
+        phase_app_id (str, optional): The ID of the Phase application. Defaults to None.
+        tags (str, optional): Comma-separated list of tags to filter secrets. Defaults to None.
+        path (str, optional): Specific path under which to fetch secrets. Defaults to '/'.
+        shell_type (str, optional): Type of shell to launch (bash, zsh, fish, powershell, etc.). Defaults to None.
+    """
+    phase = Phase()
+    console = Console()
+
+    try:
+        with Progress(
+                SpinnerColumn(),
+                *Progress.get_default_columns(),
+                console=console,
+                transient=True,
+            ) as progress:
+                task1 = progress.add_task("[bold green]Fetching secrets...", total=None)        
+
+                # Fetch all secrets
+                all_secrets = phase.get(env_name=env_name, app_name=phase_app, app_id=phase_app_id, tag=tags, path=path)
+                
+                # Organize all secrets into a dictionary for easier lookup
+                secrets_dict = {}
+                for secret in all_secrets:
+                    env_name = secret['environment']
+                    secret_path = secret['path']
+                    key = secret['key']
+                    if env_name not in secrets_dict:
+                        secrets_dict[env_name] = {}
+                    if secret_path not in secrets_dict[env_name]:
+                        secrets_dict[env_name][secret_path] = {}
+                    secrets_dict[env_name][secret_path][key] = secret['value']
+
+                # Resolve all secret references
+                resolved_secrets_dict = {}
+                for secret in all_secrets:
+                    # Attempt to resolve secret references in the value
+                    resolved_value = resolve_all_secrets(secret["value"], all_secrets, phase, secret.get('application'), secret.get('environment'))
+                    resolved_secrets_dict[secret["key"]] = resolved_value
+
+                # Count and get environment from the secrets for the message
+                secret_count = len(resolved_secrets_dict)
+                
+                # Extract application and environment names
+                applications = set(secret.get('application') for secret in all_secrets if secret['key'] in resolved_secrets_dict and secret.get('application'))
+                environments = set(secret.get('environment') for secret in all_secrets if secret['key'] in resolved_secrets_dict)
+                
+                application_message = ', '.join(applications)
+                environment_message = ', '.join(environments)
+
+                new_env = os.environ.copy()
+                new_env.update(resolved_secrets_dict)
+
+                # Set a PHASE_ENV environment variable for shell scripts to detect
+                new_env['PHASE_SHELL'] = 'true'
+                if env_name:
+                    new_env['PHASE_ENV'] = env_name
+                
+                # Determine which shell to launch
+                if shell_type:
+                    shell_cmd = get_shell_command(shell_type)
+                else:
+                    shell_cmd = get_default_shell()
+
+                if not shell_cmd:
+                    console.log("[bold red]Error:[/] Unable to determine shell to launch. Please specify a shell using --shell.")
+                    sys.exit(1)
+
+                shell_name = os.path.basename(shell_cmd[0])
+
+                # Stop the fetching secrets spinner
+                progress.stop()
+
+                # Print the message with the number of secrets injected
+                if path and path != '/':
+                    console.log(f"🐚 Initialized [bold green]{shell_name}[/] with [bold magenta]{secret_count}[/] secrets from Application: [bold cyan]{application_message}[/], Environment: [bold green]{environment_message}[/], Path: [bold yellow]{path}[/]")
+                else:
+                    console.log(f"🐚 Initialized [bold green]{shell_name}[/] with [bold magenta]{secret_count}[/] secrets from Application: [bold cyan]{application_message}[/], Environment: [bold green]{environment_message}[/]")
+                
+                console.log(f"[bold yellow]Remember:[/] Secrets are only available in this session. Type [bold]exit[/] or press [bold]Ctrl+D[/] to exit.\n")
+                
+                # Launch the interactive shell
+                try:
+                    subprocess.run(shell_cmd, env=new_env, shell=False)
+                    console.log(f"\n[bold red]🐚 Shell session ended.[/] Phase secrets are no longer available.")
+                except Exception as e:
+                    console.log(f"[bold red]Error launching shell:[/] {e}")
+                    sys.exit(1)
+
+    except ValueError as e:
+        console.log(f"Error: {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        console.log("\n[bold yellow]Shell launch interrupted.[/]")
+        sys.exit(0)

--- a/phase_cli/cmd/shell.py
+++ b/phase_cli/cmd/shell.py
@@ -64,7 +64,7 @@ def phase_shell(env_name=None, phase_app=None, phase_app_id=None, tags=None, pat
                 application_message = ', '.join(applications)
                 environment_message = ', '.join(environments)
 
-                new_env = os.environ.copy()
+                new_env = {}
                 new_env.update(resolved_secrets_dict)
 
                 # Set a PHASE_ENV environment variable for shell scripts to detect

--- a/phase_cli/main.py
+++ b/phase_cli/main.py
@@ -12,6 +12,7 @@ from phase_cli.cmd.users.switch import switch_user
 from phase_cli.cmd.users.keyring import show_keyring_info
 from phase_cli.cmd.users.logout import phase_cli_logout
 from phase_cli.cmd.run import phase_run_inject
+from phase_cli.cmd.shell import phase_shell
 from phase_cli.cmd.init import phase_init
 from phase_cli.cmd.auth import phase_auth
 from phase_cli.cmd.secrets.list import phase_list_secrets
@@ -96,6 +97,15 @@ def main ():
         run_parser.add_argument('--app-id', type=str, help=app_id_help)
         run_parser.add_argument('--path', type=str, default='/', help="Specific path under which to fetch secrets from and inject into your application. Default is '/'")
         run_parser.add_argument('--tags', type=str, help=tag_help)
+
+        # Shell command
+        shell_parser = subparsers.add_parser('shell', help='🐚 Launch a sub-shell with secrets as environment variables (BETA)')
+        shell_parser.add_argument('--env', type=str, help=env_help)
+        shell_parser.add_argument('--app', type=str, help=app_help)
+        shell_parser.add_argument('--app-id', type=str, help=app_id_help)
+        shell_parser.add_argument('--path', type=str, default='/', help="Specific path under which to fetch secrets from and inject into your shell. Default is '/'")
+        shell_parser.add_argument('--tags', type=str, help=tag_help)
+        shell_parser.add_argument('--shell', type=str, help="Specify which shell to use (bash, zsh, sh, fish, powershell, etc). If not specified, will use the current shell or system default.")
 
         # Secrets command
         secrets_parser = subparsers.add_parser('secrets', help='🗝️\u200A Manage your secrets')
@@ -280,6 +290,8 @@ def main ():
         elif args.command == 'run':
             command = ' '.join(args.command_to_run)
             phase_run_inject(command, env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, path=args.path, tags=args.tags)
+        elif args.command == 'shell':
+            phase_shell(env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, path=args.path, tags=args.tags, shell_type=args.shell)
         elif args.command == 'console':
             phase_open_console()
         elif args.command == 'docs':


### PR DESCRIPTION
This PR adds a `phase shell` sub command which will start a fresh ephemeral shell of the user's choice and securely initialize it with secrets as environment variables. This is useful for local development workflows where users need to work with many commands, script, tools and running `phase run` every time may not always be an option. The user can exit this shell by 
typing exit of pressing `Ctrl + D` as they would normally any other shell. The secrets inside of the shell are automatically cleared by the system and are not logged any anywhere else. 
 
This feature is now currently in beta, as we are exploring it's performance, usage and reliability on non-unix based platforms like Windows. 

This PR also makes small a change to the existing `phase run` sub command by printing the application name and path when a new command has been started. The path is only printed when it's !='' (not blank)

Example:
```fish
phase run "sleep 5"                      
[15:09:06] 🚀 Injected 15 secrets from Application: example-app, Environment: Development

 phase run --path / "sleep 5"
[15:25:37] 🚀 Injected 16 secrets from Application: example-app, Environment: Development, Path: /                                                                                                                                                          
```