### PR TITLE
feat: add error handling for JSON decode issues in API responses

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.19.1
+pkgver=1.19.2
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/cmd/auth.py
+++ b/phase_cli/cmd/auth.py
@@ -14,7 +14,7 @@ from phase_cli.utils.misc import open_browser, validate_url, print_phase_links
 from phase_cli.utils.crypto import CryptoUtils
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.const import PHASE_SECRETS_DIR, PHASE_CLOUD_API_HOST
-
+from rich.console import Console
 
 class SimpleHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
     """
@@ -120,7 +120,9 @@ def phase_auth(mode="webauth"):
     Returns:
         None
     """
-             
+    # Create a console object for logging warnings and errors to stderr
+    console = Console(stderr=True)
+
     server = None
     try:
         # Choose the authentication mode: webauth (default) or token-based.
@@ -132,25 +134,25 @@ def phase_auth(mode="webauth"):
             ).ask()
 
             if not phase_instance_type:
-                print("\nExiting phase...")
+                console.log("\nExiting phase...")
                 return
 
             if phase_instance_type == '🛠️  Self Hosted':
                 PHASE_API_HOST = questionary.text("Please enter your host (URL eg. https://example.com/path):").ask()
                 if not PHASE_API_HOST:
-                    print("\nExiting phase...")
+                    console.log("\nExiting phase...")
                     return
             else:
                 PHASE_API_HOST = PHASE_CLOUD_API_HOST
 
             user_email = questionary.text("Please enter your email:").ask()
             if not user_email:
-                print("\nExiting phase...")
+                console.log("\nExiting phase...")
                 return
 
             personal_access_token = getpass.getpass("Please enter Phase user token (hidden): ")
             if not personal_access_token:
-                print("\nExiting phase...")
+                console.log("\nExiting phase...")
                 return
 
             # Authenticate using the provided token
@@ -176,7 +178,7 @@ def phase_auth(mode="webauth"):
                 return
             
             if not validate_url(PHASE_API_HOST):
-                print("Invalid URL. Please ensure you include the scheme (e.g., https) and domain. Keep in mind, path and port are optional.")
+                console.log("Invalid URL. Please ensure you include the scheme (e.g., https) and domain. Keep in mind, path and port are optional.")
                 return
 
             # Start an HTTP web server at a random port and spin up the keys.
@@ -194,7 +196,7 @@ def phase_auth(mode="webauth"):
             encoded_data = base64.b64encode(raw_data.encode()).decode()
 
             # Print the link in the console
-            print(f"Please authenticate via the Phase Console: {PHASE_API_HOST}/webauth/{encoded_data}")
+            console.print(f"Please authenticate via the Phase Console: {PHASE_API_HOST}/webauth/{encoded_data}")
 
             # Open the URL silently
             open_browser(f"{PHASE_API_HOST}/webauth/{encoded_data}")
@@ -235,7 +237,7 @@ def phase_auth(mode="webauth"):
                 token_saved_in_keyring = True
             except Exception as e:
                 if os.getenv("PHASE_DEBUG") == "True":
-                    print(f"Failed to save token in keyring: {e}")
+                    console.log(f"Failed to save token in keyring: {e}")
                 token_saved_in_keyring = False
 
             # Load existing config or initialize a new one
@@ -278,11 +280,11 @@ def phase_auth(mode="webauth"):
             print_phase_links()
 
         else:
-            print("Failed to authenticate with the provided credentials.")
+            console.log("Failed to authenticate with the provided credentials.")
     except KeyboardInterrupt:
-        print("\nExiting phase...")
+        console.log("\nExiting phase...")
     except Exception as e:
-        print(f"An error occurred: {e}")
+        console.log(f"An error occurred: {e}")
         sys.exit(1)
     finally:
         if server:

--- a/phase_cli/cmd/init.py
+++ b/phase_cli/cmd/init.py
@@ -4,6 +4,7 @@ import json
 import questionary
 from phase_cli.utils.phase_io import Phase
 from phase_cli.utils.const import PHASE_ENV_CONFIG
+from rich.console import Console
 
 # Initializes a .phase.json in the root of the dir of where the command is run
 def phase_init():
@@ -12,6 +13,8 @@ def phase_init():
     """
     # Initialize the Phase class
     phase = Phase()
+    # Create a console object for logging warnings and errors to stderr
+    console = Console(stderr=True)
 
     try:
         data = phase.init()
@@ -69,12 +72,12 @@ def phase_init():
             json.dump(phase_env, f, indent=2)
         os.chmod(PHASE_ENV_CONFIG, 0o600)
 
-        print("✅ Initialization completed successfully.")
+        console.print("✅ Initialization completed successfully.")
 
     except KeyboardInterrupt:
         # Handle the Ctrl+C event quietly
         sys.exit(0)
     except Exception as e:
         # Handle other exceptions if needed
-        print(e)
+        console.log(f"Error: {e}")
         sys.exit(1)

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.19.1"
+__version__ = "1.19.2"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."


### PR DESCRIPTION
Fixes https://github.com/phasehq/console/issues/569.

This PR extends the existing utils for exception handling in `network.py` by catching cases of non-JSON responses from the Phase API.


Before the fix:

```fish
phase secrets list
[14:53:27] Error: Expecting value: line 1 column 1 (char 0)   
```

After the fix:

```fish
phase secrets list
[14:30:16] Error: 🗿 Unexpected response received from the Phase API. Please set PHASE_DEBUG=True to see the error & response.           main.py:344 
```

Response preview when DEBUG is set to True
```fish
export PHASE_DEBUG=True
~/git/phase/cli main* ❯ phase secrets list     
Traceback (most recent call last):
  File "/home/nimish/git/phase/console/.conda/lib/python3.11/site-packages/requests/models.py", line 974, in json
    return complexjson.loads(self.text, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nimish/git/phase/console/.conda/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nimish/git/phase/console/.conda/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nimish/git/phase/console/.conda/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nimish/git/phase/cli/phase_cli/utils/network.py", line 137, in fetch_phase_user
    response.json()
  File "/home/nimish/git/phase/console/.conda/lib/python3.11/site-packages/requests/models.py", line 978, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nimish/git/phase/cli/phase_cli/main.py", line 317, in main
    phase_list_secrets(args.show, env_name=args.env, phase_app=args.app, phase_app_id=args.app_id, path=args.path, tags=args.tags)
  File "/home/nimish/git/phase/cli/phase_cli/cmd/secrets/list.py", line 25, in phase_list_secrets
    secrets_data = phase.get(env_name=env_name, app_name=phase_app, app_id=phase_app_id, tag=tags, path=path)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nimish/git/phase/cli/phase_cli/utils/phase_io.py", line 181, in get
    user_response = fetch_phase_user(self._token_type, self._app_secret.app_token, self._api_host)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nimish/git/phase/cli/phase_cli/utils/network.py", line 139, in fetch_phase_user
    handle_json_decode_error(response)
  File "/home/nimish/git/phase/cli/phase_cli/utils/network.py", line 39, in handle_json_decode_error
    raise APIError(error_message)
phase_cli.exceptions.APIError: 🗿 Unexpected response received from the Phase API. Could not parse as JSON.
Response preview: <!DOCTYPE html><html lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="/_next/static/css/app/layout.css?v=1747471559677" data-precedence="next_static/css/app/layout.css"/><link rel="preload" as="script" fetchPriority="low" href="/_next/static/chunks/webpack.js?v=1747471559677"/><script src="/_next/static/chunks/main-app.js?v=1747471559677" async=""></script><script src="/_next/static/chunks/app-pages-internals... [truncated]
```