### PR TITLE
fix: alpine dependency conflicts

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -16,7 +16,13 @@ build() {
 }
 
 package() {
-    python3 setup.py install --prefix=/usr --root="$pkgdir" --skip-build    
+    python3 setup.py install --prefix=/usr --root="$pkgdir" --skip-build
     pyver=$(python3 -c "import sys; print(f'python{sys.version_info.major}.{sys.version_info.minor}')")
-    pip3 install --target="$pkgdir/usr/lib/$pyver/site-packages" -r requirements.txt
+    site_pkg_dir="$pkgdir/usr/lib/$pyver/site-packages"
+    vendor_dir="$site_pkg_dir/phase_cli/vendor"
+    mkdir -p "$vendor_dir"
+    # Install runtime deps into the private vendor dir to avoid conflicts with other packages
+    pip3 install --no-cache-dir --target="$vendor_dir" -r requirements.txt
+    # Tell Python about that directory
+    echo "phase_cli/vendor" > "$site_pkg_dir/phase_cli_vendor.pth"
 }

--- a/process_assets.py
+++ b/process_assets.py
@@ -1,9 +1,7 @@
-import os
 import argparse
 import hashlib
 import zipfile
 import shutil
-import glob
 from pathlib import Path
 
 def sha256sum(filename):
@@ -23,8 +21,11 @@ def process_artifacts(input_dir, output_dir, version):
     output_dir.mkdir(parents=True, exist_ok=True)
 
     # Define expected files and their source locations here
+    # Format: (output_file, source_dir, file_pattern)
+    # If file_pattern is None, the source_dir is a directory and will be zipped
     assets = [
-        ('phase_cli_linux_amd64_{version}.apk', 'phase-apk', '*.apk'),
+        ('phase_cli_linux_amd64_{version}.apk', 'phase_cli_linux_amd64_alpine_{version}', '*.apk'),
+        ('phase_cli_linux_arm64_{version}.apk', 'phase_cli_linux_arm64_alpine_{version}', '*.apk'),
         ('phase_cli_linux_amd64_{version}.deb', 'phase-deb', '*.deb'),
         ('phase_cli_linux_amd64_{version}.rpm', 'phase-rpm', '*.rpm'),
         ('phase_cli_linux_amd64_{version}.zip', 'Linux-binary', None),
@@ -36,12 +37,13 @@ def process_artifacts(input_dir, output_dir, version):
 
     for output_file, source_dir, file_pattern in assets:
         output_file = output_file.format(version=version)
+        source_dir = source_dir.format(version=version)
         source_path = input_dir / source_dir
         output_path = output_dir / output_file
 
         if file_pattern:
             # For APK, DEB, and RPM files
-            file_path = find_file(input_dir, file_pattern)
+            file_path = find_file(source_path, file_pattern)
             if file_path:
                 shutil.copy2(file_path, output_path)
             else:


### PR DESCRIPTION
- Group all phase cli dependencies in a managed vendor directory to avoid conflicts with other python packages
- Fixed process assets script to pick up alpine arm64 assets

Addresses: https://github.com/phasehq/cli/issues/241