### PR TITLE
fix: execute programs in a clean environment

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.19.2
+pkgver=1.19.4
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.19.3
+pkgver=1.19.2
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ phase run npm start
 ### Create a virtualenv:
 
 ```bash
-python3 -m venv venv
+python -m venv venv
 ```
 
 ### Switch to the virtualenv:

--- a/README.md
+++ b/README.md
@@ -117,35 +117,30 @@ phase run npm start
 
 ## Development:
 
-### Make sure virtualenv is installed
-
-```bash
-pip3 install virtualenv
-
-```
-
 ### Create a virtualenv:
 
 ```bash
-virtualenv phase-cli
+python3 -m venv venv
 ```
 
 ### Switch to the virtualenv:
 
 ```bash
-source phase-cli/bin/activate
+source venv/bin/activate
 ```
 
 ### Install dependencies:
 
 ```bash
-pip3 install -r requirements.txt
+pip install -r requirements.txt
 ```
 
-```
-export PYTHONPATH="$PWD"
+### Install the CLI in editable mode:
+
+```bash
+pip install -e .
 ```
 
 ```bash
-python3 phase_cli/main.py
+phase --version
 ```

--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -1,11 +1,10 @@
 import sys
-import os
 import subprocess
 from phase_cli.utils.phase_io import Phase
-from phase_cli.utils.misc import tag_matches, normalize_tag
+from phase_cli.utils.misc import clean_subprocess_env
 from phase_cli.utils.secret_referencing import resolve_all_secrets
 from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
+from rich.progress import Progress, SpinnerColumn
 
 def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, tags=None, path: str = '/'):
     """
@@ -64,10 +63,8 @@ def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, 
                 application_message = ', '.join(applications)
                 environment_message = ', '.join(environments)
 
-                new_env = os.environ.copy()
-                # Remove PyInstaller library paths to avoid conflicts with user applications
-                new_env.pop('LD_LIBRARY_PATH', None)
-                new_env.update(resolved_secrets_dict)
+                secrets_env = clean_subprocess_env()
+                secrets_env.update(resolved_secrets_dict)
 
                 # Stop the fetching secrets spinner
                 progress.stop()
@@ -79,7 +76,7 @@ def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, 
                     console.log(f"🚀 Injected [bold magenta]{secret_count}[/] secrets from Application: [bold cyan]{application_message}[/], Environment: [bold green]{environment_message}[/]\n")
                 
                 # Start and inject secrets
-                process = subprocess.run(command, shell=True, env=new_env)
+                process = subprocess.run(command, shell=True, env=secrets_env)
                 # Exit with the same return code as the subprocess
                 sys.exit(process.returncode)
 

--- a/phase_cli/cmd/run.py
+++ b/phase_cli/cmd/run.py
@@ -65,6 +65,8 @@ def phase_run_inject(command, env_name=None, phase_app=None, phase_app_id=None, 
                 environment_message = ', '.join(environments)
 
                 new_env = os.environ.copy()
+                # Remove PyInstaller library paths to avoid conflicts with user applications
+                new_env.pop('LD_LIBRARY_PATH', None)
                 new_env.update(resolved_secrets_dict)
 
                 # Stop the fetching secrets spinner

--- a/phase_cli/cmd/shell.py
+++ b/phase_cli/cmd/shell.py
@@ -74,8 +74,10 @@ def phase_shell(env_name=None, phase_app=None, phase_app_id=None, tags=None, pat
 
                 # Set a PHASE_* environment variable for shell scripts to detect
                 secrets_env['PHASE_SHELL'] = 'true'
-                if env_name:
-                    secrets_env['PHASE_ENV'] = env_name
+                if environments:
+                    secrets_env['PHASE_ENV'] = list(environments)[0]
+                if applications:
+                    secrets_env['PHASE_APP'] = list(applications)[0]
 
                 # Ensure TERM is present for proper line-editing/rendering in shells like zsh
                 if not secrets_env.get('TERM'):

--- a/phase_cli/cmd/update.py
+++ b/phase_cli/cmd/update.py
@@ -19,8 +19,11 @@ def phase_cli_update():
         # Make the script executable
         os.chmod("temp_install.sh", 0o755)
 
-        # Execute the script
-        subprocess.call(["./temp_install.sh"])
+        # Execute the script with clean environment to avoid library conflicts
+        clean_env = os.environ.copy()
+        # Remove any LD_LIBRARY_PATH that might point to bundled libraries
+        clean_env.pop('LD_LIBRARY_PATH', None)
+        subprocess.call(["./temp_install.sh"], env=clean_env)
 
         # Remove the temporary file after execution
         os.remove("temp_install.sh")

--- a/phase_cli/cmd/update.py
+++ b/phase_cli/cmd/update.py
@@ -2,10 +2,12 @@ import requests
 import subprocess
 import os
 import sys
+from rich.console import Console
 
 def phase_cli_update():
     # URL of the remote bash script
     url = "https://pkg.phase.dev/install.sh"
+    console = Console()
     
     try:
         # Fetch the script
@@ -23,18 +25,44 @@ def phase_cli_update():
         clean_env = os.environ.copy()
         # Remove any LD_LIBRARY_PATH that might point to bundled libraries
         clean_env.pop('LD_LIBRARY_PATH', None)
-        subprocess.call(["./temp_install.sh"], env=clean_env)
+        
+        # Use subprocess.run instead of subprocess.call for better error handling
+        result = subprocess.run(["./temp_install.sh"], env=clean_env, capture_output=True, text=True)
+        
+        # Check if the script execution was successful
+        if result.returncode != 0:
+            console.log(f"[bold red]Error:[/] Update script failed with exit code {result.returncode}")
+            if result.stderr:
+                console.log(f"[bold red]Error details:[/] {result.stderr.strip()}")
+            if result.stdout:
+                console.log(f"[bold yellow]Output:[/] {result.stdout.strip()}")
+            sys.exit(1)
 
         # Remove the temporary file after execution
         os.remove("temp_install.sh")
         
-        print("Update completed successfully.")
+        console.log("[bold green]✅ Update completed successfully.[/]")
+        
     except requests.RequestException as e:
-        print(f"Error fetching the update script: {e}")
+        console.log(f"[bold red]Error:[/] Failed to fetch the update script: {e}")
         sys.exit(1)
-    except subprocess.CalledProcessError:
-        print("Error executing the update script.")
+    except FileNotFoundError:
+        console.log("[bold red]Error:[/] Failed to create or execute the temporary install script")
+        sys.exit(1)
+    except PermissionError as e:
+        console.log(f"[bold red]Error:[/] Permission denied: {e}")
+        console.log("[bold yellow]Tip:[/] Try running with sudo privileges or check file permissions")
+        sys.exit(1)
+    except OSError as e:
+        console.log(f"[bold red]Error:[/] OS error occurred: {e}")
         sys.exit(1)
     except Exception as e:
-        print(f"An unexpected error occurred: {e}")
+        console.log(f"[bold red]Error:[/] An unexpected error occurred: {e}")
         sys.exit(1)
+    finally:
+        # Ensure cleanup even if an error occurs
+        if os.path.exists("temp_install.sh"):
+            try:
+                os.remove("temp_install.sh")
+            except OSError:
+                pass

--- a/phase_cli/cmd/update.py
+++ b/phase_cli/cmd/update.py
@@ -3,6 +3,7 @@ import subprocess
 import os
 import sys
 from rich.console import Console
+from phase_cli.utils.misc import clean_subprocess_env
 
 def phase_cli_update():
     # URL of the remote bash script
@@ -22,9 +23,7 @@ def phase_cli_update():
         os.chmod("temp_install.sh", 0o755)
 
         # Execute the script with clean environment to avoid library conflicts
-        clean_env = os.environ.copy()
-        # Remove any LD_LIBRARY_PATH that might point to bundled libraries
-        clean_env.pop('LD_LIBRARY_PATH', None)
+        clean_env = clean_subprocess_env()
         
         # Use subprocess.run instead of subprocess.call for better error handling
         result = subprocess.run(["./temp_install.sh"], env=clean_env, capture_output=True, text=True)

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.19.3"
+__version__ = "1.19.2"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.19.2"
+__version__ = "1.19.4"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -438,8 +438,11 @@ def open_browser(url):
                 cmd = ['xdg-open', url]
 
             # Suppress output by redirecting to devnull
+            # Use clean environment to avoid library conflicts with bundled libraries
+            clean_env = os.environ.copy()
+            clean_env.pop('LD_LIBRARY_PATH', None)
             with open(os.devnull, 'w') as fnull:
-                subprocess.run(cmd, stdout=fnull, stderr=fnull, check=True)
+                subprocess.run(cmd, stdout=fnull, stderr=fnull, check=True, env=clean_env)
         except Exception as e:
             # If all methods fail, instruct the user to open the URL manually
             print(f"Unable to automatically open the Phase Console in your default web browser")

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -428,6 +428,11 @@ def clean_subprocess_env():
     
     PyInstaller bundles its own copies of system libraries which can interfere with 
     subprocess execution when spawned from a PyInstaller-built application.
+
+    TODO: Considering filtering for: 
+        '_MEIPASS',            # PyInstaller temporary directory
+        '_MEIPASS2',           # PyInstaller temporary directory (alternative)
+        'PYTHONPATH',          # Python module search path (can contain bundled modules)
     
     Returns:
         dict: A copy of os.environ with PyInstaller library paths removed.


### PR DESCRIPTION
This PR fixes with how the Phase CLI would start other processes or application for the purposes of opening a web browser, updating the CLI to the latest version, injecting secrets into applications etc., with certain flags that were passing PyInstaller specific contexts via the `LD_LIBRARY_PATH` and or the `DYLD_LIBRARY_PATH` environment variable, which caused the resulting process or the application to have inconsistent contexts of certain dependencies such as OpenSSL. This fix simply filters them out. This PR also contains a small improvements in exception handling for the phase update` command.

More details can be found at: https://github.com/pyinstaller/pyinstaller/blob/34508a2cda1072718a81ef1d5a660ce89e62d295/doc/common-issues-and-pitfalls.rst#linux-and-unix-like-oses

Fixes: https://github.com/phasehq/cli/issues/203