### PR TITLE
feat: phase auth svc account

### DIFF
--- a/phase_cli/cmd/auth.py
+++ b/phase_cli/cmd/auth.py
@@ -128,54 +128,73 @@ def phase_auth(mode="webauth"):
         # Choose the authentication mode: webauth (default) or token-based.
         if mode == 'token':
             # Manual token-based authentication
-            phase_instance_type = questionary.select(
-                'Choose your Phase instance type:',
-                choices=['☁️  Phase Cloud', '🛠️  Self Hosted']
-            ).ask()
+            # Check if PHASE_HOST environment variable is set for headless operation
+            PHASE_API_HOST = os.getenv("PHASE_HOST")
+            
+            if PHASE_API_HOST:
+                console.log(f"Using PHASE_HOST environment variable: {PHASE_API_HOST}")
+            else:
+                # Interactive mode: ask user to choose instance type
+                phase_instance_type = questionary.select(
+                    'Choose your Phase instance type:',
+                    choices=['☁️  Phase Cloud', '🛠️  Self Hosted']
+                ).ask()
 
-            if not phase_instance_type:
-                console.log("\nExiting phase...")
-                return
-
-            if phase_instance_type == '🛠️  Self Hosted':
-                PHASE_API_HOST = questionary.text("Please enter your host (URL eg. https://example.com/path):").ask()
-                if not PHASE_API_HOST:
+                if not phase_instance_type:
                     console.log("\nExiting phase...")
                     return
-            else:
-                PHASE_API_HOST = PHASE_CLOUD_API_HOST
 
-            user_email = questionary.text("Please enter your email:").ask()
-            if not user_email:
+                if phase_instance_type == '🛠️  Self Hosted':
+                    PHASE_API_HOST = questionary.text("Please enter your host (URL eg. https://example.com/path):").ask()
+                    if not PHASE_API_HOST:
+                        console.log("\nExiting phase...")
+                        return
+                else:
+                    PHASE_API_HOST = PHASE_CLOUD_API_HOST
+
+            auth_token = getpass.getpass("Please enter Personal Access Token (PAT) or a Service Account Token (hidden): ")
+            if not auth_token:
                 console.log("\nExiting phase...")
                 return
-
-            personal_access_token = getpass.getpass("Please enter Phase user token (hidden): ")
-            if not personal_access_token:
-                console.log("\nExiting phase...")
-                return
+            
+            # Check if it's a service token (they start with 'pss_service:')
+            is_service_token = auth_token.startswith('pss_service:')
+            user_email = None
+            
+            if not is_service_token:
+                user_email = questionary.text("Please enter your email:").ask()
+                if not user_email:
+                    console.log("\nExiting phase...")
+                    return
 
             # Authenticate using the provided token
-            phase = Phase(init=False, pss=personal_access_token, host=PHASE_API_HOST)
+            phase = Phase(init=False, pss=auth_token, host=PHASE_API_HOST)
             result = phase.auth()
 
         else:
             # Web-based authentication
-            phase_instance_type = questionary.select(
-                'Choose your Phase instance type:',
-                choices=['☁️  Phase Cloud', '🛠️  Self Hosted']
-            ).ask()
-
-            if not phase_instance_type:
-                return
-
-            if phase_instance_type == '🛠️  Self Hosted':
-                PHASE_API_HOST = questionary.text("Please enter your host (URL eg. https://example.com/path):").ask()
+            # Check if PHASE_HOST environment variable is set for headless operation
+            PHASE_API_HOST = os.getenv("PHASE_HOST")
+            
+            if PHASE_API_HOST:
+                console.log(f"Using PHASE_HOST environment variable: {PHASE_API_HOST}")
             else:
-                PHASE_API_HOST = PHASE_CLOUD_API_HOST
+                # Interactive mode: ask user to choose instance type
+                phase_instance_type = questionary.select(
+                    'Choose your Phase instance type:',
+                    choices=['☁️  Phase Cloud', '🛠️  Self Hosted']
+                ).ask()
 
-            if not PHASE_API_HOST:
-                return
+                if not phase_instance_type:
+                    return
+
+                if phase_instance_type == '🛠️  Self Hosted':
+                    PHASE_API_HOST = questionary.text("Please enter your host (URL eg. https://example.com/path):").ask()
+                else:
+                    PHASE_API_HOST = PHASE_CLOUD_API_HOST
+
+                if not PHASE_API_HOST:
+                    return
             
             if not validate_url(PHASE_API_HOST):
                 console.log("Invalid URL. Please ensure you include the scheme (e.g., https) and domain. Keep in mind, path and port are optional.")
@@ -218,12 +237,16 @@ def phase_auth(mode="webauth"):
 
             # Authenticate with the decrypted pss
             phase = Phase(init=False, pss=decrypted_personal_access_token, host=PHASE_API_HOST)
-            personal_access_token=decrypted_personal_access_token
+            auth_token = decrypted_personal_access_token
             result = phase.auth()
 
         if result == "Success":
             user_data = phase.init()
-            user_id = user_data["user_id"]
+            # Handle both user accounts (PATs) and service accounts (service tokens)
+            account_id = user_data.get("user_id") or user_data.get("account_id")
+            if not account_id:
+                raise ValueError("Neither user_id nor account_id found in authentication response")
+            
             offline_enabled = user_data["offline_enabled"]
             wrapped_key_share = None if not offline_enabled else user_data["wrapped_key_share"]
 
@@ -233,7 +256,7 @@ def phase_auth(mode="webauth"):
 
             # Save the credentials in the Phase keyring
             try:
-                keyring.set_password(f"phase-cli-user-{user_id}", "pss", personal_access_token)
+                keyring.set_password(f"phase-cli-user-{account_id}", "pss", auth_token)
                 token_saved_in_keyring = True
             except Exception as e:
                 if os.getenv("PHASE_DEBUG") == "True":
@@ -250,22 +273,24 @@ def phase_auth(mode="webauth"):
 
             # Update the config_data with the new user, ensuring no duplicates
             existing_users = {user['id']: user for user in config_data["phase-users"]}
-            user_data = {
-                "email": user_email,
+            user_data_config = {
                 "host": PHASE_API_HOST,
-                "id": user_id,
+                "id": account_id,
                 "organization_id": organization_id,
                 "organization_name": organization_name,
                 "wrapped_key_share": wrapped_key_share
             }
+            # Only add email if it exists (service accounts may not have one)
+            if user_email:
+                user_data_config["email"] = user_email
             # If saving to keyring failed, save the token in the config_data
             if not token_saved_in_keyring:
-                user_data["token"] = personal_access_token
-            existing_users[user_id] = user_data
+                user_data_config["token"] = auth_token
+            existing_users[account_id] = user_data_config
             config_data["phase-users"] = list(existing_users.values())
 
             # Set the latest user as the default user
-            config_data["default-user"] = user_id
+            config_data["default-user"] = account_id
 
             # Save the updated configuration
             os.makedirs(PHASE_SECRETS_DIR, exist_ok=True)

--- a/phase_cli/cmd/secrets/import_env.py
+++ b/phase_cli/cmd/secrets/import_env.py
@@ -1,6 +1,6 @@
 import sys
 from phase_cli.utils.phase_io import Phase
-from phase_cli.utils.misc import get_default_user_id, sanitize_value
+from phase_cli.utils.misc import sanitize_value
 from rich.console import Console
 
 def phase_secrets_env_import(env_file, env_name=None, phase_app=None, phase_app_id=None, path: str = '/'):

--- a/phase_cli/cmd/users/logout.py
+++ b/phase_cli/cmd/users/logout.py
@@ -4,7 +4,7 @@ import sys
 import shutil
 import keyring
 from phase_cli.utils.const import PHASE_SECRETS_DIR, CONFIG_FILE
-from phase_cli.utils.misc import get_default_user_id
+from phase_cli.utils.misc import get_default_account_id
 
 def save_config(config_data):
     """Saves the updated configuration data to the config file."""
@@ -17,9 +17,9 @@ def phase_cli_logout(purge=False):
 
     if purge:
         try:
-            all_user_ids = get_default_user_id(all_ids=True)
-            for user_id in all_user_ids:
-                keyring.delete_password(f"phase-cli-user-{user_id}", "pss")
+            all_account_ids = get_default_account_id(all_ids=True)
+            for account_id in all_account_ids:
+                keyring.delete_password(f"phase-cli-user-{account_id}", "pss")
 
             # Delete PHASE_SECRETS_DIR if it exists
             if os.path.exists(PHASE_SECRETS_DIR):
@@ -39,12 +39,12 @@ def phase_cli_logout(purge=False):
         with open(config_file_path, 'r') as f:
             config_data = json.load(f)
 
-        # Identify the default user and remove their credentials
-        default_user_id = get_default_user_id()
-        if default_user_id:
-            keyring.delete_password(f"phase-cli-user-{default_user_id}", "pss")
-            # Remove the default user from the config
-            config_data['phase-users'] = [user for user in config_data['phase-users'] if user['id'] != default_user_id]
+        # Identify the default account and remove their credentials
+        default_account_id = get_default_account_id()
+        if default_account_id:
+            keyring.delete_password(f"phase-cli-user-{default_account_id}", "pss")
+            # Remove the default account from the config
+            config_data['phase-users'] = [user for user in config_data['phase-users'] if user['id'] != default_account_id]
             # If there are no users left, remove the default user ID as well
             if not config_data['phase-users']:
                 config_data.pop('default-user', None)

--- a/phase_cli/cmd/users/switch.py
+++ b/phase_cli/cmd/users/switch.py
@@ -31,8 +31,8 @@ def switch_user():
     # Prepare user choices, including a visual separator as a title.
     # Also, create a mapping for the partial UUID to the full UUID.
     uuid_mapping = {}
-    user_choices = [Separator("🏢 Organization, ✉️\u200A Email, ☁️\u200A Phase Host, 🆔 User ID")] + [
-        f"{user.get('organization_name', 'N/A') if user.get('organization_name') else 'N/A'}, {user['email']}, {user['host']}, {user['id'][:8]}"
+    user_choices = [Separator("🏢 Organization, ✉️\u200A Email, ☁️\u200A Phase Host, 🆔 Account ID")] + [
+        f"{user.get('organization_name', 'N/A') if user.get('organization_name') else 'N/A'}, {user.get('email', 'Service Account')}, {user['host']}, {user['id'][:8]}"
         for user in config_data['phase-users']
     ]
     
@@ -43,7 +43,7 @@ def switch_user():
     try:
         while True:
             selected = select(
-                "Choose a user to switch to:",
+                "Choose an account to switch to:",
                 choices=user_choices
             ).ask()
 
@@ -59,13 +59,13 @@ def switch_user():
             if full_uuid:
                 config_data['default-user'] = full_uuid
                 save_config(config_data)
-                print(f"Switched to user 🙋: {selected}")
+                print(f"Switched to account 🙋: {selected}")
                 break
             else:
-                print("User switch failed.")
+                print("Account switch failed.")
                 sys.exit(1)
     except KeyboardInterrupt:
         sys.exit(0)
     except Exception as e:
-        print(f"Error switching user: {e}")
+        print(f"Error switching account: {e}")
         sys.exit(1)

--- a/phase_cli/cmd/users/whoami.py
+++ b/phase_cli/cmd/users/whoami.py
@@ -27,8 +27,9 @@ def phase_users_whoami():
             sys.exit(1)
 
         # Print the default user details
-        print(f"✉️\u200A Email: {default_user['email']}")
-        print(f"🙋 User ID: {default_user['id']}")
+        email = default_user.get('email', 'N/A (Service Account)')
+        print(f"✉️\u200A Email: {email}")
+        print(f"🙋 Account ID: {default_user['id']}")
         print(f"🏢 Organization: {default_user['organization_name']}")
         print(f"☁️\u200A Host: {default_user['host']}")
 

--- a/phase_cli/utils/keyring.py
+++ b/phase_cli/utils/keyring.py
@@ -2,7 +2,7 @@ import os
 import sys
 import getpass
 import keyring
-from phase_cli.utils.misc import get_default_user_id, get_default_user_token
+from phase_cli.utils.misc import get_default_account_id, get_default_user_token
 
 def get_credentials():
     # Use environment variables if available
@@ -11,9 +11,9 @@ def get_credentials():
     if pss:
         return pss
 
-    # Fetch user ID for keyring service name
-    default_user_id = get_default_user_id()
-    service_name = f"phase-cli-user-{default_user_id}"
+    # Fetch account ID for keyring service name
+    default_account_id = get_default_account_id()
+    service_name = f"phase-cli-user-{default_account_id}"
 
     try:
         pss = keyring.get_password(service_name, "pss")

--- a/phase_cli/utils/misc.py
+++ b/phase_cli/utils/misc.py
@@ -212,18 +212,20 @@ def get_default_user_host() -> str:
     raise ValueError(f"No user found in config.json with id: {default_user_id}.")
 
 
-def get_default_user_id(all_ids=False) -> Union[str, List[str]]:
+def get_default_account_id(all_ids=False) -> Union[str, List[str]]:
     """
-    Fetch the default user's ID from the config file in PHASE_SECRETS_DIR.
+    Fetch the default account ID from the config file in PHASE_SECRETS_DIR.
+    
+    This function handles both user accounts (PATs) and service accounts (service tokens).
 
     Parameters:
-    - all_ids (bool): If set to True, returns a list of all user IDs. Otherwise, returns the default user's ID.
+    - all_ids (bool): If set to True, returns a list of all account IDs. Otherwise, returns the default account ID.
 
     Returns:
-    - Union[str, List[str]]: The default user's ID, or a list of all user IDs if all_ids is True.
+    - Union[str, List[str]]: The default account ID, or a list of all account IDs if all_ids is True.
 
     Raises:
-    - ValueError: If the config file is not found or if the default user's ID is missing.
+    - ValueError: If the config file is not found or if the default account ID is missing.
     """
     config_file_path = os.path.join(PHASE_SECRETS_DIR, 'config.json')
     
@@ -237,6 +239,25 @@ def get_default_user_id(all_ids=False) -> Union[str, List[str]]:
         return [user['id'] for user in config_data.get('phase-users', [])]
     else:
         return config_data.get("default-user")
+
+
+def get_default_user_id(all_ids=False) -> Union[str, List[str]]:
+    """
+    Fetch the default user's ID from the config file in PHASE_SECRETS_DIR.
+    
+    DEPRECATED: Use get_default_account_id() instead for better compatibility with service accounts.
+    This function is kept for backward compatibility.
+
+    Parameters:
+    - all_ids (bool): If set to True, returns a list of all user IDs. Otherwise, returns the default user's ID.
+
+    Returns:
+    - Union[str, List[str]]: The default user's ID, or a list of all user IDs if all_ids is True.
+
+    Raises:
+    - ValueError: If the config file is not found or if the default user's ID is missing.
+    """
+    return get_default_account_id(all_ids)
 
 
 def get_default_user_org(config_file_path):


### PR DESCRIPTION
This PR adds the ability to use Service Account Token with `phase auth`.

Changes:
- Added support for Service Account in phase auth
- In `phase auth` if PHASE_HOST is available, the user will not be prompted for selecting instance type. A message with log this.
- Updated phase users sub-sub commands to support Service Accounts
- Updated misc utils to use Service Account id contexts whenever applicable