### PR TITLE
feat: optimize secret referencing performance

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Phase <info@phase.dev>
 pkgname=phase
-pkgver=1.19.4
+pkgver=1.19.5
 pkgrel=0
 pkgdesc="Phase CLI"
 url="https://phase.dev"

--- a/phase_cli/utils/const.py
+++ b/phase_cli/utils/const.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-__version__ = "1.19.4"
+__version__ = "1.19.5"
 __ph_version__ = "v1"
 
 description = "Securely manage application secrets and environment variables with Phase."

--- a/phase_cli/utils/secret_referencing.py
+++ b/phase_cli/utils/secret_referencing.py
@@ -271,10 +271,11 @@ def resolve_secret_reference(ref: str, secrets_dict: Dict[str, Dict[str, Dict[st
     original_ref = ref
     app_name, env_name, path, key_name = _parse_reference_context(ref, current_application_name, current_env_name)
 
-    # Try in-memory dict first
-    in_mem = _lookup_in_memory_value(secrets_dict, env_name, path, key_name, current_env_name)
-    if in_mem is not None:
-        return in_mem
+    # Try in-memory dict first only for same-application references
+    if app_name == current_application_name:
+        in_mem = _lookup_in_memory_value(secrets_dict, env_name, path, key_name, current_env_name)
+        if in_mem is not None:
+            return in_mem
 
     # Ensure caches for both original and matched env variants, then try cache
     _ensure_cached_for_env_variants(phase, app_name, env_name, path, secrets_dict)

--- a/tests/secret_referencing.py
+++ b/tests/secret_referencing.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch
+import phase_cli.utils.secret_referencing as sr
 from phase_cli.utils.secret_referencing import resolve_secret_reference, resolve_all_secrets, EnvironmentNotFoundException
 from phase_cli.utils.const import SECRET_REF_REGEX
 
@@ -30,7 +31,22 @@ class MockPhase:
     def get(self, env_name, app_name, keys, path):
         # Handle cross-application references
         if app_name == "other_app" and env_name == "dev" and path == "/":
-            return [{"key": "API_KEY", "value": "other_app_api_key"}]
+            return [
+                {"key": "API_KEY", "value": "other_app_api_key"},
+                {"key": "POSTGRESQL_USER", "value": "pg_user"},
+                {"key": "POSTGRESQL_PASSWORD", "value": "pg_password"},
+                {"key": "POSTGRESQL_DB", "value": "db"},
+                {"key": "POSTGRESQL_HOST", "value": "localhost"},
+                {"key": "POSTGRESQL_URL", "value": "postgresql://${/creds/POSTGRESQL_USER}:${/creds/POSTGRESQL_PASSWORD}@${POSTGRESQL_HOST}/${POSTGRESQL_DB}"},
+                {"key": "A", "value": "${B}"},
+                {"key": "B", "value": "${C}"},
+                {"key": "C", "value": "${A}"},
+            ]
+        elif app_name == "other_app" and env_name == "dev" and path == "/creds":
+            return [
+                {"key": "POSTGRESQL_USER", "value": "pg_user"},
+                {"key": "POSTGRESQL_PASSWORD", "value": "pg_password"},
+            ]
         elif app_name == "other_app" and env_name == "prod" and path == "/config":
             return [{"key": "DB_PASSWORD", "value": "other_app_db_password"}]
         elif app_name == "backend_api" and env_name == "production" and path == "/frontend":
@@ -51,6 +67,11 @@ def current_env_name():
 @pytest.fixture
 def current_application_name():
     return "test_app"
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    sr._SECRETS_CACHE.clear()
 
 def test_resolve_local_reference_root(phase, current_application_name, current_env_name):
     ref = "KEY"
@@ -164,3 +185,109 @@ def test_resolve_cross_app_frontend_example(phase, current_application_name, cur
     ref = "backend_api::production./frontend/SECRET_KEY"
     resolved_value = resolve_secret_reference(ref, secrets_dict, phase, current_application_name, current_env_name)
     assert resolved_value == "backend_api_secret_key"
+
+
+def test_recursive_cross_app_resolution(phase, current_application_name, current_env_name):
+    # App A value referencing App B value which itself contains references
+    value = "DB=${other_app::dev.POSTGRESQL_URL}"
+    all_secrets = [
+        {"environment": current_env_name, "path": "/", "key": "POSTGRESQL_URL", "value": "postgresql://${other_app::dev.POSTGRESQL_USER}:${other_app::dev.POSTGRESQL_PASSWORD}@${other_app::dev.POSTGRESQL_HOST}/${other_app::dev.POSTGRESQL_DB}"}
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "DB=postgresql://pg_user:pg_password@localhost/db"
+
+
+def test_partial_env_case_insensitive_variants(phase, current_application_name, current_env_name):
+    value = "X=${development.DEBUG};Y=${DEV.DEBUG};Z=${DeVeLoPmEnT.DEBUG}"
+    all_secrets = [
+        {"environment": "Development", "path": "/", "key": "DEBUG", "value": "true"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "X=true;Y=true;Z=true"
+
+
+def test_partial_env_substring_variants(phase, current_application_name, current_env_name):
+    value = "A=${deve.DEBUG};B=${lop.DEBUG}"
+    all_secrets = [
+        {"environment": "Development", "path": "/", "key": "DEBUG", "value": "on"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "A=on;B=on"
+
+
+def test_partial_env_ambiguous_prefers_shortest(phase, current_application_name, current_env_name):
+    value = "Z=${de.DEBUG}"
+    all_secrets = [
+        {"environment": "dev", "path": "/", "key": "DEBUG", "value": "a"},
+        {"environment": "development", "path": "/", "key": "DEBUG", "value": "b"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "Z=a"
+
+
+def test_ambiguous_exact_wins(phase, current_application_name, current_env_name):
+    value = "Z=${dev.DEBUG}"
+    all_secrets = [
+        {"environment": "dev", "path": "/", "key": "DEBUG", "value": "a"},
+        {"environment": "development", "path": "/", "key": "DEBUG", "value": "b"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "Z=a"
+
+
+def test_recursive_local_multi_layer(phase, current_application_name, current_env_name):
+    value = "CONN=${/db/URL}"
+    all_secrets = [
+        {"environment": current_env_name, "path": "/db", "key": "USER", "value": "u"},
+        {"environment": current_env_name, "path": "/db", "key": "PASS", "value": "p"},
+        {"environment": current_env_name, "path": "/db", "key": "HOST", "value": "h"},
+        {"environment": current_env_name, "path": "/db", "key": "DB", "value": "d"},
+        {"environment": current_env_name, "path": "/db", "key": "URL", "value": "postgresql://${/db/USER}:${/db/PASS}@${/db/HOST}/${/db/DB}"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "CONN=postgresql://u:p@h/d"
+
+
+def test_recursive_missing_inner_reference(phase, current_application_name, current_env_name):
+    value = "CONN=${/db/URL}"
+    all_secrets = [
+        {"environment": current_env_name, "path": "/db", "key": "USER", "value": "u"},
+        {"environment": current_env_name, "path": "/db", "key": "PASS", "value": "p"},
+        {"environment": current_env_name, "path": "/db", "key": "URL", "value": "postgresql://${/db/USER}:${/db/PASS}@${/db/HOST}/${/db/DB}"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert "${/db/HOST}" in resolved_value and "${/db/DB}" in resolved_value
+
+
+def test_cycle_self_reference_cross_app(phase, current_application_name, current_env_name):
+    value = "X=${other_app::dev.A}"
+    all_secrets = []
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value.startswith("X=${")
+    assert "A" in resolved_value
+
+
+def test_cycle_multi_secret_loop_cross_app(phase, current_application_name, current_env_name):
+    value = "X=${other_app::dev.A} Y=${other_app::dev.B} Z=${other_app::dev.C}"
+    all_secrets = []
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert "${" in resolved_value  # at least one unresolved placeholder due to cycle
+
+
+def test_cycle_across_env_case_variants_local(phase, current_application_name, current_env_name):
+    value = "X=${Development.DEBUG}"
+    all_secrets = [
+        {"environment": "Development", "path": "/", "key": "DEBUG", "value": "${development.DEBUG}"},
+        {"environment": "development", "path": "/", "key": "DEBUG", "value": "${Development.DEBUG}"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "X=${Development.DEBUG}" or resolved_value == "X=${development.DEBUG}"
+
+
+def test_multiple_occurrences_same_reference(phase, current_application_name, current_env_name):
+    value = "A=${KEY};B=${KEY}"
+    all_secrets = [
+        {"environment": current_env_name, "path": "/", "key": "KEY", "value": "v"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "A=v;B=v"

--- a/tests/test_secret_referencing_extended.py
+++ b/tests/test_secret_referencing_extended.py
@@ -1,0 +1,155 @@
+import pytest
+import phase_cli.utils.secret_referencing as sr
+from phase_cli.utils.secret_referencing import resolve_secret_reference, resolve_all_secrets, EnvironmentNotFoundException
+
+
+class MockPhase:
+    def get(self, env_name, app_name, keys, path):
+        # Cross-app: other_app dev root
+        if app_name == "other_app" and env_name == "dev" and path == "/":
+            return [
+                {"key": "API_KEY", "value": "other_app_api_key"},
+                {"key": "POSTGRESQL_USER", "value": "pg_user"},
+                {"key": "POSTGRESQL_PASSWORD", "value": "pg_password"},
+                {"key": "POSTGRESQL_DB", "value": "db"},
+                {"key": "POSTGRESQL_HOST", "value": "localhost"},
+                {"key": "POSTGRESQL_URL", "value": "postgresql://${/creds/POSTGRESQL_USER}:${/creds/POSTGRESQL_PASSWORD}@${POSTGRESQL_HOST}/${POSTGRESQL_DB}"},
+                # Cycle keys
+                {"key": "A", "value": "${B}"},
+                {"key": "B", "value": "${C}"},
+                {"key": "C", "value": "${A}"},
+            ]
+        # Cross-app: other_app dev creds path
+        if app_name == "other_app" and env_name == "dev" and path == "/creds":
+            return [
+                {"key": "POSTGRESQL_USER", "value": "pg_user"},
+                {"key": "POSTGRESQL_PASSWORD", "value": "pg_password"},
+            ]
+        # Cross-app: other_app prod config path
+        if app_name == "other_app" and env_name == "prod" and path == "/config":
+            return [{"key": "DB_PASSWORD", "value": "other_app_db_password"}]
+        # Cross-app: backend_api production frontend path
+        if app_name == "backend_api" and env_name == "production" and path == "/frontend":
+            return [{"key": "SECRET_KEY", "value": "backend_api_secret_key"}]
+        # Regular env reference example
+        if env_name == "prod" and path == "/frontend":
+            return [{"key": "SECRET_KEY", "value": "prod_secret_value"}]
+        raise EnvironmentNotFoundException(env_name=env_name)
+
+
+@pytest.fixture
+def phase():
+    return MockPhase()
+
+
+@pytest.fixture
+def current_env_name():
+    return "current"
+
+
+@pytest.fixture
+def current_application_name():
+    return "test_app"
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    sr._SECRETS_CACHE.clear()
+
+
+def test_partial_env_case_insensitive_variants(phase, current_application_name, current_env_name):
+    value = "X=${development.DEBUG};Y=${DEV.DEBUG};Z=${DeVeLoPmEnT.DEBUG}"
+    all_secrets = [
+        {"environment": "Development", "path": "/", "key": "DEBUG", "value": "true"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "X=true;Y=true;Z=true"
+
+
+def test_partial_env_substring_variants(phase, current_application_name, current_env_name):
+    value = "A=${deve.DEBUG};B=${lop.DEBUG}"
+    all_secrets = [
+        {"environment": "Development", "path": "/", "key": "DEBUG", "value": "on"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "A=on;B=on"
+
+
+def test_partial_env_ambiguous_prefers_shortest(phase, current_application_name, current_env_name):
+    value = "Z=${de.DEBUG}"
+    all_secrets = [
+        {"environment": "dev", "path": "/", "key": "DEBUG", "value": "a"},
+        {"environment": "development", "path": "/", "key": "DEBUG", "value": "b"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "Z=a"
+
+
+def test_ambiguous_exact_wins(phase, current_application_name, current_env_name):
+    value = "Z=${dev.DEBUG}"
+    all_secrets = [
+        {"environment": "dev", "path": "/", "key": "DEBUG", "value": "a"},
+        {"environment": "development", "path": "/", "key": "DEBUG", "value": "b"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "Z=a"
+
+
+def test_recursive_local_multi_layer(phase, current_application_name, current_env_name):
+    value = "CONN=${/db/URL}"
+    all_secrets = [
+        {"environment": current_env_name, "path": "/db", "key": "USER", "value": "u"},
+        {"environment": current_env_name, "path": "/db", "key": "PASS", "value": "p"},
+        {"environment": current_env_name, "path": "/db", "key": "HOST", "value": "h"},
+        {"environment": current_env_name, "path": "/db", "key": "DB", "value": "d"},
+        {"environment": current_env_name, "path": "/db", "key": "URL", "value": "postgresql://${/db/USER}:${/db/PASS}@${/db/HOST}/${/db/DB}"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "CONN=postgresql://u:p@h/d"
+
+
+def test_recursive_missing_inner_reference(phase, current_application_name, current_env_name):
+    value = "CONN=${/db/URL}"
+    all_secrets = [
+        {"environment": current_env_name, "path": "/db", "key": "USER", "value": "u"},
+        {"environment": current_env_name, "path": "/db", "key": "PASS", "value": "p"},
+        {"environment": current_env_name, "path": "/db", "key": "URL", "value": "postgresql://${/db/USER}:${/db/PASS}@${/db/HOST}/${/db/DB}"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert "${/db/HOST}" in resolved_value and "${/db/DB}" in resolved_value
+
+
+def test_cycle_self_reference_cross_app(phase, current_application_name, current_env_name):
+    value = "X=${other_app::dev.A}"
+    all_secrets = []
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value.startswith("X=${")
+    assert "A" in resolved_value
+
+
+def test_cycle_multi_secret_loop_cross_app(phase, current_application_name, current_env_name):
+    value = "X=${other_app::dev.A} Y=${other_app::dev.B} Z=${other_app::dev.C}"
+    all_secrets = []
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert "${" in resolved_value  # at least one unresolved placeholder due to cycle
+
+
+def test_cycle_across_env_case_variants_local(phase, current_application_name, current_env_name):
+    value = "X=${Development.DEBUG}"
+    all_secrets = [
+        {"environment": "Development", "path": "/", "key": "DEBUG", "value": "${development.DEBUG}"},
+        {"environment": "development", "path": "/", "key": "DEBUG", "value": "${Development.DEBUG}"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "X=${Development.DEBUG}" or resolved_value == "X=${development.DEBUG}"
+
+
+def test_multiple_occurrences_same_reference(phase, current_application_name, current_env_name):
+    value = "A=${KEY};B=${KEY}"
+    all_secrets = [
+        {"environment": current_env_name, "path": "/", "key": "KEY", "value": "v"},
+    ]
+    resolved_value = resolve_all_secrets(value, all_secrets, phase, current_application_name, current_env_name)
+    assert resolved_value == "A=v;B=v"
+
+


### PR DESCRIPTION
This PR improves secret referencing resolution performance by using a client-side in-memory cache, fetching secrets in parallel and significantly reducing the number of API calls made to the Phase API. This dramatic reduction in API calls would mean fewer run-ins with API rate limits and further reduction of the number of secret audit logs being generated. Added recursive secret resolution support and extended partial env name matching logic. 

This is especially helpful for users with larger number of cross application referenced secrets (very often more than 100+ secrets) for use cases involving the user of another applications environment as a shared or common application.


Benchmarks: 

Example application and environment structure.

```tf
terraform {
  required_providers {
    phase = {
      source  = "phasehq/phase"
    }
  }
}

provider "phase" {
  phase_token = var.phase_access_token
}

variable "phase_access_token" {
  description = "Phase personal access token"
  type        = string
  sensitive   = true
  default     = null
}

variable "app_a_id" {
  type    = string
  default = "a6ae711a-7698-45d2-910e-af2f3dd7a05a"
}

variable "app_b_id" {
  type    = string
  default = "c660dd1c-9a75-4975-8a77-8df0603a5852"
}

variable "app_c_id" {
  type    = string
  default = "cfc93688-e6ae-4187-926e-7775bb1a2436"
}

variable "app_d_id" {
  type    = string
  default = "86ca4282-4ab7-494c-bd40-a27bdbf209a8"
}

variable "app_e_id" {
  type    = string
  default = "f664a249-2a9e-4fd8-97e0-d36b59f8e14f"
}

variable "environment" {
  type    = string
  default = "development"
}

locals {
  max_per_app = 500
  group_size  = 125
  app_letters = ["B", "C", "D", "E"]

  b_count = local.max_per_app
  c_count = local.max_per_app
  d_count = local.max_per_app
  e_count = local.max_per_app

  a_count = local.max_per_app
}

resource "phase_secret" "app_b" {
  count       = local.b_count
  app_id      = var.app_b_id
  env         = var.environment
  path        = "secret_ref"
  key         = "SECRET_${count.index + 1}"
  value       = "FROM APP B DEVELOPMENT"
}

resource "phase_secret" "app_c" {
  count       = local.c_count
  app_id      = var.app_c_id
  env         = var.environment
  path        = "secret_ref"
  key         = "SECRET_${count.index + 1}"
  value       = "FROM APP C DEVELOPMENT"
}

resource "phase_secret" "app_d" {
  count       = local.d_count
  app_id      = var.app_d_id
  env         = var.environment
  path        = "secret_ref"
  key         = "SECRET_${count.index + 1}"
  value       = "FROM APP D DEVELOPMENT"
}

resource "phase_secret" "app_e" {
  count       = local.e_count
  app_id      = var.app_e_id
  env         = var.environment
  path        = "secret_ref"
  key         = "SECRET_${count.index + 1}"
  value       = "FROM APP E DEVELOPMENT"
}

resource "phase_secret" "app_a" {
  count       = local.a_count
  app_id      = var.app_a_id
  env         = var.environment
  key         = "SECRET_${count.index + 1}"
  value       = format(
    "$${%s::%s.secret_ref/SECRET_%d}",
    local.app_letters[floor(count.index / local.group_size)],
    var.environment,
    (count.index % local.group_size) + 1,
  )
  depends_on  = [
    phase_secret.app_b,
    phase_secret.app_c,
    phase_secret.app_d,
    phase_secret.app_e,
  ]
}
```


Before:

```fish
...
SECRET_319="FROM APP D DEVELOPMENT"
SECRET_11="FROM APP B DEVELOPMENT"
SECRET_397="FROM APP E DEVELOPMENT"
SECRET_25="FROM APP B DEVELOPMENT"
SECRET_167="FROM APP C DEVELOPMENT"
phase secrets export  1.66s user 0.28s system 3% cpu 50.425 total
```

After:

```fish
...
SECRET_319="FROM APP D DEVELOPMENT"
SECRET_11="FROM APP B DEVELOPMENT"
SECRET_397="FROM APP E DEVELOPMENT"
SECRET_25="FROM APP B DEVELOPMENT"
SECRET_167="FROM APP C DEVELOPMENT"
phase secrets export  0.60s user 0.08s system 4% cpu 13.677 total
```