### PR TITLE
feat: add Amazon Linux support to installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ can_install_without_sudo() {
                 return 0
             fi
             ;;
-        fedora|rhel|centos)
+        fedora|rhel|centos|amzn)
             if rpm -q rpm >/dev/null 2>&1; then
                 return 0
             fi
@@ -73,7 +73,7 @@ install_tool() {
             ubuntu|debian)
                 apt-get update && apt-get install -y $TOOL
                 ;;
-            fedora|rhel|centos)
+            fedora|rhel|centos|amzn)
                 yum install -y $TOOL
                 ;;
             alpine)
@@ -89,7 +89,7 @@ install_tool() {
             ubuntu|debian)
                 sudo apt-get update && sudo apt-get install -y $TOOL
                 ;;
-            fedora|rhel|centos)
+            fedora|rhel|centos|amzn)
                 sudo yum install -y $TOOL
                 ;;
             alpine)
@@ -103,11 +103,15 @@ install_tool() {
 }
 
 check_required_tools() {
-    for TOOL in wget curl jq sha256sum unzip; do
+    for TOOL in wget curl jq unzip; do
         if ! command -v $TOOL > /dev/null; then
             install_tool $TOOL
         fi
     done
+    # sha256sum is provided by coreutils on most distros
+    if ! command -v sha256sum > /dev/null; then
+        install_tool coreutils
+    fi
 }
 
 get_latest_version() {
@@ -212,7 +216,7 @@ install_package() {
             fi
             ;;
 
-        fedora|rhel|centos)
+        fedora|rhel|centos|amzn)
             PACKAGE_URL="$BASE_URL/v$VERSION/phase_cli_linux_amd64_$VERSION.rpm"
             wget_download $PACKAGE_URL $TMPDIR/phase_cli_linux_amd64_$VERSION.rpm
             verify_checksum "$TMPDIR/phase_cli_linux_amd64_$VERSION.rpm" "$PACKAGE_URL.sha256"


### PR DESCRIPTION
- Updated the installation script to include Amazon Linux (amzn) in the supported distributions for both installation checks and tool installations.
- Adjusted the required tools check to ensure `sha256sum` is installed via `coreutils` if not already available, enhancing compatibility across distributions.