### PR TITLE
feat: add offline support with automatic secret caching

### DIFF
--- a/src/cmd/auth.go
+++ b/src/cmd/auth.go
@@ -138,7 +138,7 @@ func runTokenAuth(cmd *cobra.Command, host string) error {
 	}
 
 	var wrappedKeyShare *string
-	if userData.OfflineEnabled && userData.WrappedKeyShare != "" {
+	if userData.WrappedKeyShare != "" {
 		wrappedKeyShare = &userData.WrappedKeyShare
 	}
 

--- a/src/cmd/auth_aws.go
+++ b/src/cmd/auth_aws.go
@@ -161,7 +161,7 @@ func runAWSIAMAuth(cmd *cobra.Command, host string) error {
 	}
 
 	var wrappedKeyShare *string
-	if userData.OfflineEnabled && userData.WrappedKeyShare != "" {
+	if userData.WrappedKeyShare != "" {
 		wrappedKeyShare = &userData.WrappedKeyShare
 	}
 

--- a/src/cmd/auth_azure.go
+++ b/src/cmd/auth_azure.go
@@ -77,7 +77,7 @@ func runAzureAuth(cmd *cobra.Command, host string) error {
 	}
 
 	var wrappedKeyShare *string
-	if userData.OfflineEnabled && userData.WrappedKeyShare != "" {
+	if userData.WrappedKeyShare != "" {
 		wrappedKeyShare = &userData.WrappedKeyShare
 	}
 

--- a/src/cmd/auth_webauth.go
+++ b/src/cmd/auth_webauth.go
@@ -161,7 +161,7 @@ func runWebAuth(cmd *cobra.Command, host string) error {
 	}
 
 	var wrappedKeyShare *string
-	if userData.OfflineEnabled && userData.WrappedKeyShare != "" {
+	if userData.WrappedKeyShare != "" {
 		wrappedKeyShare = &userData.WrappedKeyShare
 	}
 

--- a/src/cmd/users_logout.go
+++ b/src/cmd/users_logout.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/phasehq/cli/pkg/config"
 	"github.com/phasehq/cli/pkg/keyring"
+	"github.com/phasehq/cli/pkg/offline"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,10 @@ func runUsersLogout(cmd *cobra.Command, args []string) error {
 
 		accountID := ids[0]
 		keyring.DeleteCredentials(accountID)
+
+		// Clean up offline cache for this user
+		cacheDir := offline.CacheDir(config.PhaseSecretsDir, accountID)
+		os.RemoveAll(cacheDir)
 
 		if err := config.RemoveUser(accountID); err != nil {
 			return fmt.Errorf("failed to update config: %w", err)

--- a/src/go.mod
+++ b/src/go.mod
@@ -13,6 +13,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+replace github.com/phasehq/golang-sdk/v2 => ../../golang-sdk
+
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect

--- a/src/go.mod
+++ b/src/go.mod
@@ -6,14 +6,12 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/manifoldco/promptui v0.9.0
-	github.com/phasehq/golang-sdk/v2 v2.1.1
+	github.com/phasehq/golang-sdk/v2 v2.2.0
 	github.com/spf13/cobra v1.8.0
 	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/term v0.39.0
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-replace github.com/phasehq/golang-sdk/v2 => ../../golang-sdk
 
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -71,6 +71,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
+github.com/phasehq/golang-sdk/v2 v2.2.0 h1:d6tpEeoSGZoxNukjq59rEGlevU+R1c4j7KacZls83cM=
+github.com/phasehq/golang-sdk/v2 v2.2.0/go.mod h1:W7sFK8701qK1uuixHKOEIs9irqIUDvWPZGwg58zRyjE=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/src/pkg/errors/errors.go
+++ b/src/pkg/errors/errors.go
@@ -12,15 +12,16 @@ import (
 func FormatSDKError(err error) string {
 	var netErr *network.NetworkError
 	if errors.As(err, &netErr) {
+		const offlineHint = ". Please set PHASE_OFFLINE=1 to use previously available cached data."
 		switch netErr.Kind {
 		case "dns":
-			return fmt.Sprintf("🗿 Network error: Could not resolve host '%s'. Please check the Phase host URL and your connection", netErr.Host)
+			return fmt.Sprintf("🗿 Network error: Could not resolve host '%s'%s", netErr.Host, offlineHint)
 		case "connection":
-			return "🗿 Network error: Could not connect to the Phase host. Please check that the server is running and the host URL is correct"
+			return "🗿 Network error: Could not connect to the Phase host" + offlineHint
 		case "timeout":
-			return "🗿 Network error: Request timed out. Please check your connection and try again"
+			return "🗿 Network error: Request timed out" + offlineHint
 		default:
-			return fmt.Sprintf("🗿 Network error: %s", netErr.Detail)
+			return fmt.Sprintf("🗿 Network error: %s%s", netErr.Detail, offlineHint)
 		}
 	}
 

--- a/src/pkg/errors/errors.go
+++ b/src/pkg/errors/errors.go
@@ -12,7 +12,7 @@ import (
 func FormatSDKError(err error) string {
 	var netErr *network.NetworkError
 	if errors.As(err, &netErr) {
-		const offlineHint = ". Please set PHASE_OFFLINE=1 to use previously available cached data."
+		const offlineHint = ". Set PHASE_OFFLINE=1 to use cached data if available."
 		switch netErr.Kind {
 		case "dns":
 			return fmt.Sprintf("🗿 Network error: Could not resolve host '%s'%s", netErr.Host, offlineHint)

--- a/src/pkg/offline/offline.go
+++ b/src/pkg/offline/offline.go
@@ -1,0 +1,18 @@
+package offline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CacheDir returns the offline cache directory for a given account ID.
+func CacheDir(secretsDir, accountID string) string {
+	return filepath.Join(secretsDir, "offline", accountID)
+}
+
+// IsOffline returns true if PHASE_OFFLINE is set to "1" or "true".
+func IsOffline() bool {
+	v := os.Getenv("PHASE_OFFLINE")
+	return v == "1" || strings.EqualFold(v, "true")
+}

--- a/src/pkg/phase/phase.go
+++ b/src/pkg/phase/phase.go
@@ -140,8 +140,13 @@ func GetConfig(appName, envName, appID string) (string, string, string) {
 }
 
 // getCacheDir returns the offline cache directory for the current default user.
-// Returns empty string if no user is configured (e.g. service token without config).
+// Returns empty string if no user is configured or if ad-hoc env var auth is
+// active (PHASE_SERVICE_TOKEN), since the token identity may differ from the
+// config user and would pollute their cache.
 func getCacheDir() string {
+	if os.Getenv("PHASE_SERVICE_TOKEN") != "" {
+		return ""
+	}
 	user, err := config.GetDefaultUser()
 	if err != nil || user == nil {
 		return ""

--- a/src/pkg/phase/phase.go
+++ b/src/pkg/phase/phase.go
@@ -10,6 +10,7 @@ import (
 	"github.com/phasehq/cli/pkg/ai"
 	"github.com/phasehq/cli/pkg/config"
 	"github.com/phasehq/cli/pkg/keyring"
+	"github.com/phasehq/cli/pkg/offline"
 	"github.com/phasehq/cli/pkg/version"
 	sdk "github.com/phasehq/golang-sdk/v2/phase"
 	"github.com/phasehq/golang-sdk/v2/phase/misc"
@@ -37,7 +38,20 @@ func NewPhase(init bool, pss string, host string) (*sdk.Phase, error) {
 
 	setUserAgent()
 
-	return sdk.New(pss, host, false)
+	p, err := sdk.New(pss, host, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure offline: always cache on success, only serve from cache when PHASE_OFFLINE=1
+	if cacheDir := getCacheDir(); cacheDir != "" {
+		p.SetOfflineConfig(&sdk.OfflineConfig{
+			CacheDir: cacheDir,
+			Offline:  offline.IsOffline(),
+		})
+	}
+
+	return p, nil
 }
 
 func setUserAgent() {
@@ -123,6 +137,16 @@ func GetConfig(appName, envName, appID string) (string, string, string) {
 		envName = "Development"
 	}
 	return appName, envName, appID
+}
+
+// getCacheDir returns the offline cache directory for the current default user.
+// Returns empty string if no user is configured (e.g. service token without config).
+func getCacheDir() string {
+	user, err := config.GetDefaultUser()
+	if err != nil || user == nil {
+		return ""
+	}
+	return offline.CacheDir(config.PhaseSecretsDir, user.ID)
 }
 
 func coalesce(a, b string) string {


### PR DESCRIPTION
## Summary
Adds offline support to the Phase CLI. Encrypted API responses are cached locally on every successful fetch. Users set `PHASE_OFFLINE=1` to serve secrets from cache when network is unavailable.

**Depends on:** phasehq/golang-sdk#21

## Behavior

| PHASE_OFFLINE | Caches on success | Serves from cache | Network errors |
|---------------|-------------------|-------------------|----------------|
| unset | Yes | No | Fail with hint |
| `1` / `true` | No (skips network) | Yes | N/A |

## Changes
- `cmd/auth*.go` — always store `wrapped_key_share` (remove `OfflineEnabled` gate)
- `cmd/users_logout.go` — clear offline cache on logout
- `pkg/offline/` — `IsOffline()` and `CacheDir()` helpers
- `pkg/phase/phase.go` — configures SDK `OfflineConfig` from `PHASE_OFFLINE` env var
- `pkg/errors/errors.go` — network error messages include `PHASE_OFFLINE=1` hint
- `go.mod` — bump `golang-sdk` to v2.2.0

## Cache structure
```
~/.phase/secrets/offline/{user_id}/
  userdata.json                              # encrypted AppKeyResponse
  secrets/
    {sha256(env|app|appID|path)}.json        # encrypted secrets array
```

## Test plan
- [x] `phase auth` → verify `wrapped_key_share` in `~/.phase/secrets/config.json`
- [x] `phase secrets list` → verify cache files are encrypted JSON (not plaintext)
- [x] Disconnect network → `phase secrets list` → fails with `PHASE_OFFLINE=1` hint
- [x] `PHASE_OFFLINE=1 phase secrets list` → serve from cache
- [x] `PHASE_OFFLINE=1 phase secrets create ...` → error cleanly
- [x] Dynamic secrets + `PHASE_OFFLINE=1` → skipped with warning
- [x] `PHASE_OFFLINE=0 PHASE_HOST=https://bogus:777 phase secrets list` → no fallback, clean error