### PR TITLE
added the ability to read PHASE_SERVICE_TOKEN env var

### DIFF
--- a/src/cmd/auth.go
+++ b/src/cmd/auth.go
@@ -83,15 +83,23 @@ func runAuth(cmd *cobra.Command, args []string) error {
 
 func runTokenAuth(cmd *cobra.Command, host string) error {
 	// Get token
-	fmt.Print("Please enter Personal Access Token (PAT) or Service Account Token (hidden): ")
-	tokenBytes, err := term.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		return fmt.Errorf("failed to read token: %w", err)
-	}
-	fmt.Println()
-	authToken := strings.TrimSpace(string(tokenBytes))
-	if authToken == "" {
-		return fmt.Errorf("token is required")
+
+	token := os.Getenv("PHASE_SERVICE_TOKEN")
+
+	if host == "" {
+		fmt.Print("Please enter Personal Access Token (PAT) or Service Account Token (hidden): ")
+		tokenBytes, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return fmt.Errorf("failed to read token: %w", err)
+		}
+		fmt.Println()
+		authToken := strings.TrimSpace(string(tokenBytes))
+		if authToken == "" {
+			return fmt.Errorf("token is required")
+		}
+	}else{
+		authToken = token
+		fmt.Fprintf(os.Stderr, "Using PHASE_SERVICE_TOKEN environment variable for authentication\n")
 	}
 
 	isPersonalToken := strings.HasPrefix(authToken, "pss_user:")


### PR DESCRIPTION
Hi, 

Using phase in docker i had some problems using a service access token and the auth command.

Currently the auth command doest not work without user inputs for mode = token, so i added the ability to read the PHASE_SERVICE_TOKEN var to bypass user input if the token is a service token. 

