### PR TITLE
ci: test on macOS and Windows, and actually run go test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,14 @@ on:
 
 jobs:
   test:
-    name: Go Test & Vet
-    runs-on: ubuntu-latest
+    name: Go Test & Vet (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CGO_ENABLED: "0"
     steps:
       - uses: actions/checkout@v6
 
@@ -24,6 +30,10 @@ jobs:
         working-directory: src
         run: go vet ./...
 
+      - name: Test
+        working-directory: src
+        run: go test ./...
+
       - name: Build (smoke test)
         working-directory: src
-        run: CGO_ENABLED=0 go build -o /dev/null ./
+        run: go build ./...


### PR DESCRIPTION
## What

Expands the reusable test workflow (`.github/workflows/test.yml`) to run on
Linux, macOS, and Windows via an OS matrix, and adds a real `go test ./...`
step (the job was named "Go Test & Vet" but only ran `go vet` + a build check).

Resolves phasehq/cli#307

## Why

- We ship macOS and Windows binaries via GoReleaser but only tested on
  `ubuntu-latest`, so platform-specific regressions (keyring, paths, terminal
  handling) could ship unnoticed — see #80.
- The suite wasn't being executed at all, on any OS.

## Changes

- Add matrix `os: [ubuntu-latest, macos-latest, windows-latest]` with
  `fail-fast: false`.
- Add a `go test ./...` step.
- Make the build step cross-platform: move `CGO_ENABLED=0` to a job-level
  `env:` block (the inline `VAR=value` prefix is bash-only and breaks on
  Windows' default PowerShell), and replace `go build -o /dev/null ./` with
  `go build ./...` (`/dev/null` doesn't exist on Windows).

Since `test.yml` is called by both `main.yml` and `release.yml`, this covers
PR CI and the release gate in one change.

## Testing

- `go test ./...` passes locally — 30 tests across `cmd`, `pkg/ai`,
  `pkg/config`, `pkg/util`.
- `GOOS=windows go vet ./...` and `GOOS=windows go build ./...` are clean.
- CI on this PR now runs the suite on all three OSes.